### PR TITLE
NowPlaying Improvements: seek buttons, play/pause track item syncing, replay button, shortcuts.

### DIFF
--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -57,6 +57,20 @@ const plainLyrics = computed(() => {
   return playingTrack.value.txt_lyrics
 })
 
+const forward10 = computed(() => {
+  if (!playingTrack.value) {
+    return null
+  }
+  return Math.min(duration.value, progress.value + 10)
+})
+
+const reverse10 = computed(() => {
+  if (!playingTrack.value) {
+    return null
+  }
+  return Math.max(0, progress.value - 10)
+})
+
 const humanDuration = (seconds) => {
   return new Date(seconds * 1000).toISOString().slice(11, 19)
 }
@@ -72,7 +86,6 @@ onMounted(async () => {
   keydownEvent.value = document.addEventListener('keydown', (event) => {
     switch (event.code) {
       case 'Space':
-        break;
       case 'Enter':
         event.preventDefault()
         if (status.value==='playing') {

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -29,6 +29,7 @@
 
 <script setup>
 import { computed } from '@vue/reactivity'
+import { ref, onMounted, onUnmounted } from 'vue'
 import Seek from './now-playing/Seek.vue'
 import LyricsViewer from './now-playing/LyricsViewer.vue'
 import PlainLyricsViewer from './now-playing/PlainLyricsViewer.vue'
@@ -36,6 +37,7 @@ import { Play, Pause, Replay } from 'mdue'
 import { usePlayer } from '@/composables/player.js'
 
 const { playingTrack, status, duration, progress, playTrack, pause, resume, seek } = usePlayer()
+const keydownEvent = ref(null)
 
 const lyrics = computed(() => {
   if (!playingTrack.value) {
@@ -56,4 +58,31 @@ const plainLyrics = computed(() => {
 const humanDuration = (seconds) => {
   return new Date(seconds * 1000).toISOString().slice(11, 19)
 }
+
+
+onUnmounted(async () => {
+  if (keydownEvent.value) {
+    document.removeEventListener(keydownEvent.value)
+  }
+})
+
+onMounted(async () => {
+  keydownEvent.value = document.addEventListener('keydown', (event) => {
+    switch (event.code) {
+      case 'Space':
+        break;
+      case 'Enter':
+        if (status.value==='playing') {
+          pause()
+        } else if (playingTrack.value && status.value==='stopped') {
+          playTrack(playingTrack.value)
+        } else {
+          resume()
+        }
+        break;
+      default:
+        break;
+    }
+  })
+})
 </script>

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -16,8 +16,9 @@
           </div>
         </div>
         <div class="basis-1/3 flex-1 flex justify-center items-center">
-          <button v-if="status !== 'playing'" @click.prevent="resume" class="button button-primary text-white p-2 rounded-full text-xl"><Play /></button>
-          <button v-else @click.prevent="pause" class="button button-primary text-white p-2 rounded-full text-xl"><Pause /></button>
+          <button v-if="status === 'playing'" @click.prevent="pause" class="button button-primary text-white p-2 rounded-full text-xl"><Pause /></button>
+          <button v-else-if="playingTrack && status === 'stopped'" @click.prevent="playTrack(playingTrack)" class="button button-primary text-white p-2 rounded-full text-xl"><Replay /></button>
+          <button v-else @click.prevent="resume" class="button button-primary text-white p-2 rounded-full text-xl"><Play /></button>
         </div>
         <div class="basis-1/3 flex-1">
         </div>
@@ -31,10 +32,10 @@ import { computed } from '@vue/reactivity'
 import Seek from './now-playing/Seek.vue'
 import LyricsViewer from './now-playing/LyricsViewer.vue'
 import PlainLyricsViewer from './now-playing/PlainLyricsViewer.vue'
-import { Play, Pause } from 'mdue'
+import { Play, Pause, Replay } from 'mdue'
 import { usePlayer } from '@/composables/player.js'
 
-const { playingTrack, status, duration, progress, pause, resume, seek } = usePlayer()
+const { playingTrack, status, duration, progress, playTrack, pause, resume, seek } = usePlayer()
 
 const lyrics = computed(() => {
   if (!playingTrack.value) {

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -16,9 +16,11 @@
           </div>
         </div>
         <div class="basis-1/3 flex-1 flex justify-center items-center">
+          <button @click.prevent="seek(reverse10)" class="button button-secondary p-2 m-2 rounded-full text-xl"><Rewind_10 /></button>
           <button v-if="status === 'playing'" @click.prevent="pause" class="button button-primary text-white p-2 rounded-full text-xl"><Pause /></button>
           <button v-else-if="playingTrack && status === 'stopped'" @click.prevent="playTrack(playingTrack)" class="button button-primary text-white p-2 rounded-full text-xl"><Replay /></button>
           <button v-else @click.prevent="resume" class="button button-primary text-white p-2 rounded-full text-xl"><Play /></button>
+          <button @click.prevent="seek(forward10)" class="button button-secondary p-2 m-2 rounded-full text-xl"><FastForward_10 /></button>
         </div>
         <div class="basis-1/3 flex-1">
         </div>
@@ -33,7 +35,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import Seek from './now-playing/Seek.vue'
 import LyricsViewer from './now-playing/LyricsViewer.vue'
 import PlainLyricsViewer from './now-playing/PlainLyricsViewer.vue'
-import { Play, Pause, Replay } from 'mdue'
+import { Play, Pause, Replay, Rewind_10, FastForward_10 } from 'mdue'
 import { usePlayer } from '@/composables/player.js'
 
 const { playingTrack, status, duration, progress, playTrack, pause, resume, seek } = usePlayer()
@@ -72,6 +74,7 @@ onMounted(async () => {
       case 'Space':
         break;
       case 'Enter':
+        event.preventDefault()
         if (status.value==='playing') {
           pause()
         } else if (playingTrack.value && status.value==='stopped') {
@@ -79,6 +82,14 @@ onMounted(async () => {
         } else {
           resume()
         }
+        break;
+      case 'ArrowLeft':
+        event.preventDefault()
+        seek(reverse10.value)
+        break;
+      case 'ArrowRight':
+        event.preventDefault()
+        seek(forward10.value)
         break;
       default:
         break;

--- a/src/components/library/track-list/TrackItem.vue
+++ b/src/components/library/track-list/TrackItem.vue
@@ -37,7 +37,9 @@
     <!-- Action buttons -->
     <div class="flex-none w-[15%] h-full flex justify-end items-center p-1">
       <div v-if="track" class="flex justify-end items-center gap-1">
-        <button class="text-brave-30 hover:bg-brave-30 hover:text-white rounded p-2 transition" @click.prevent="playTrack(track)"><Play /></button>
+        <button v-if="isPlaying && status ==='playing'" @click.prevent="pause" class="text-brave-30 hover:bg-brave-30 hover:text-white rounded p-2 transition"><Pause /></button>
+        <button v-else-if="isPlaying && status === 'stopped'" @click.prevent="playTrack(track)" class="text-brave-30 hover:bg-brave-30 hover:text-white rounded p-2 transition"><Replay /></button>
+        <button v-else v-on="isPlaying ? {click: resume} : {click: () => playTrack(track)}" class="text-brave-30 hover:bg-brave-30 hover:text-white rounded p-2 transition"><Play /></button>
         <button class="text-brave-30 hover:bg-brave-30 hover:text-white rounded p-2 transition" @click.prevent="searchLyrics(track)"><TextSearch /></button>
         <button class="text-brave-30 hover:bg-brave-30 hover:text-white rounded p-2 transition" @click.prevent="editLyrics(track)"><PlaylistEdit /></button>
       </div>
@@ -46,7 +48,7 @@
 </template>
 
 <script setup>
-import { Play, TextSearch, PlaylistEdit } from 'mdue'
+import { Play, Pause, TextSearch, PlaylistEdit, Replay } from 'mdue'
 import { humanDuration } from '../../../utils/human-duration.js'
 import { useSearchLyrics } from '../../../composables/search-lyrics.js'
 import { useEditLyrics } from '../../../composables/edit-lyrics.js'
@@ -56,7 +58,7 @@ import { invoke } from '@tauri-apps/api/tauri'
 import { listen } from '@tauri-apps/api/event'
 import { usePlayer } from '@/composables/player.js'
 
-const { playTrack, playingTrack } = usePlayer()
+const { playTrack, playingTrack, status, pause, resume } = usePlayer()
 
 const { searchLyrics } = useSearchLyrics()
 const { editLyrics } = useEditLyrics()


### PR DESCRIPTION
Here are the list of changes:
- Fast-forward and rewind buttons (10 seconds)
- Play/pause in the NowPlaying component is synced with the TrackItem button
- Replay button for when the song is finished
- shortcut keys for each button
  - space/enter for play/pause/replay
  - left for rewind
  - right for fast-forward

I think I would like to implement next/previous buttons as well, but that requires managing the track list state across different tabs, so I'll probably add that in a different PR. Let me know if you want anything changed.