### PR TITLE
feat(src_tauri:fs_track): use `WalkDir` instead of `globwalk`

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1242,17 +1242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
-dependencies = [
- "bitflags 1.3.2",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "gobject-sys"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,7 +1879,6 @@ version = "0.3.2"
 dependencies = [
  "anyhow",
  "data-encoding",
- "globwalk",
  "indoc",
  "kira",
  "lofty",
@@ -1906,6 +1894,7 @@ dependencies = [
  "tauri-build",
  "thiserror",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,6 @@ tauri-build = { version = "1.3", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.4", features = [ "shell-open", "devtools", "dialog-all", "global-shortcut-all", "os-all", "path-all", "protocol-all", "window-all"] }
-globwalk = "0.8.1"
 reqwest = { version = "0.11.12", features = ["json"] }
 lofty = "0.19.2"
 anyhow = "1.0.71"
@@ -31,6 +30,7 @@ data-encoding = "2.4.0"
 kira = "0.8.7"
 symphonia = { version = "0.5.2", features = ["all"] }
 regex = "1.10.4"
+walkdir = "2"
 
 [features]
 # by default Tauri runs in production mode


### PR DESCRIPTION
Migrated to walkdir because it has the ability to follow symlinks. 

This is my first time writing rust code, so i probably did some mistakes, please let me know. 

Also looking that the project we can achieve much lower load times, if we make use of parallel loading. 
Preliminarily search suggest making use of [jwalk](https://github.com/Byron/jwalk). More discussion needs to take place before any code changes. (bench-marking on large set of files) 