### PR TITLE
fix(plain-text-lint): do not raise instrumental tag as an error

### DIFF
--- a/src/utils/plain-text-lint.js
+++ b/src/utils/plain-text-lint.js
@@ -2,6 +2,11 @@ export const executeLint = (source) => {
   const lines = source.split('\n').map(line => line.trim())
   const problems = []
 
+  // If there's only one line with content `[au: instrumental]`, that is still valid
+  if (lines.length === 1 && lines[0].match(/^\[au: instrumental\]$/)) {
+    return problems
+  }
+
   lines.forEach((content, index) => {
     if (content.trim()) {
       // Check for lines starting with an opening square bracket


### PR DESCRIPTION
When writing lyrics, the 'Mark as instrumental' button replaces the file contents with `[au: instrumental]` but the linter flags this as an error. This does not allow the file to be published, even though it is well-formatted.

![Instrumental tag publishing](https://github.com/user-attachments/assets/dc176349-c245-421b-a86b-53009093516e)
![Linter error after clicking publish](https://github.com/user-attachments/assets/07296218-29e0-4b95-b34a-6b0c7ef9bbfc)

This change checks if the file contents contain only the instrumental tag, and bypasses the rest of the linter if so. I did this to avoid possible issues with a file that contains other lines besides the instrumental tag.