### PR TITLE
Seek: round progressPercent to thousandths

### DIFF
--- a/src/components/now-playing/Seek.vue
+++ b/src/components/now-playing/Seek.vue
@@ -57,22 +57,26 @@ const chooseProgress = _throttle((value) => {
   }, 500)
 }, 200)
 
+const roundThousandths = (num) => {
+  return Math.round(num * 1000.0) / 1000.0
+}
+
 onMounted(() => {
   if (!props.duration || !props.progress) return
 
-  progressPercent.value = props.progress / props.duration
+  progressPercent.value = roundThousandths(props.progress / props.duration)
 })
 
 watch(() => props.progress, (newProgress) => {
   if (!props.duration || !newProgress) return
   if (isGracePeriod.value) return
 
-  progressPercent.value = newProgress / props.duration
+  progressPercent.value = roundThousandths(newProgress / props.duration)
 })
 
 watch(() => props.duration, (newDuration) => {
   if (!props.progress || !newDuration) return
 
-  progressPercent.value = props.progress / newDuration
+  progressPercent.value = roundThousandths(props.progress / newDuration)
 })
 </script>


### PR DESCRIPTION
The `progress` currently updates every `40ms` which re-computes `progressPercent`. Vue needs to do a layout each time in order to update the `ViewSliderDot` inside `Seek`'s `VueSlider`.

To reduce the CPU usage of these updates and make the interface more responsive, round `progressPercent` to the nearest `0.001`. This will limit layout updates to about `1000` over the duration of a track. Since this is approximately the same as the default window width, there isn't much impact to the smoothness of the seek slider while playing a track. If the user resizes the window to be wider, the slider will scroll slightly less smoothly than before. However, this does not reduce the precision if the user seeks manually.

Discovered while researching #194