### PR TITLE
EditLyrics: reduce CPU usage

### DIFF
--- a/src/components/library/EditLyrics.vue
+++ b/src/components/library/EditLyrics.vue
@@ -95,13 +95,12 @@
 
       <!-- NOTE: AsyncCodemirror component does not have @wheel event handler, so it has to be handled here (in the container) -->
       <div class="relative h-full w-full" id="cm-container" ref="cmContainer">
-        <div class="overflow-hidden absolute w-full" :style="{ height: `${cmHeight}px` }" @wheel="handleWheel">
+        <div class="overflow-hidden absolute w-full" :style="{ height: `${cmHeight}px`, fontSize: `${codemirrorStyle.fontSize}em` }" @wheel="handleWheel">
           <AsyncCodemirror
             v-if="shouldLoadCodeMirror"
             v-model="unifiedLyrics"
             placeholder="Lyrics is currently empty"
             class="codemirror-custom h-full outline-none"
-            :style="{ fontSize: `${codemirrorStyle.fontSize}em` }"
             :autofocus="true"
             :indent-with-tab="true"
             :tab-size="2"


### PR DESCRIPTION
Editing lyrics caused CPU usage to jump to 100%. In devtools I saw many "Styles Invalidated" events. By removing portions of the `EditLyrics` component I found the cause was the `AsyncCodemirror` `style` property. This issue occurs even if I set `:style="{}"`.

Since the parent `div` already has a style property, I moved the `fontSize` there and combined with the existing `height` field. Unfortunately I don't yet understand why this has such a significant performance impact.

Discovered while researching #194