### PR TITLE
Fix: Fix broken publish button when editing lyrics from LRCLIB tab (#229)

### DIFF
--- a/src/components/library/my-lrclib/EditLyrics.vue
+++ b/src/components/library/my-lrclib/EditLyrics.vue
@@ -245,9 +245,23 @@ const resetCodemirrorFontSize = () => {
 const lyricsUpdated = (newLyrics) => {
   const parsed = Lrc.parse(newLyrics)
   runner.value = new Runner(parsed)
-  isDirty.value = true
   lyricsLintResult.value = executeLyricsLint(newLyrics)
   plainTextLintResult.value = executePlainTextLint(newLyrics)
+
+  const isLyricsSynced = /^\[.*\]/m.test(unifiedLyrics.value) // Can be a little finnicky when switching between synced/plain lyrics but it's better than using 'editingTrack.value.syncedLyrics'
+  if (isLyricsSynced) {
+    if (lyricsLintResult.value.length > 0) {
+      isDirty.value = true
+    } else {
+      isDirty.value = false
+    }
+  } else {
+    if (plainTextLintResult.value.length > 0) {
+      isDirty.value = true
+    } else {
+      isDirty.value = false
+    }
+  }
 }
 
 const rewind100 = () => {


### PR DESCRIPTION
`isDirty` was set to `true` whenever any edits were made but was never set back to `false` again to enable the publish button.

New code now checks whether lyrics are/aren't synced then checks for errors accordingly.