### PR TITLE
Added Browser Based Remote Screen Docker File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
+
+ENV TITLE=LRCGET \
+        NO_GAMEPAD=true
+
+RUN apt-get update
+RUN curl -L https://github.com/tranxuanthang/lrcget/releases/latest/download/LRCGET_0.9.3_amd64.deb > package.deb && \
+        apt-get install -y ./package.deb && rm package.deb && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
+
+# Add LRCGET to start on startup
+RUN echo "/usr/bin/LRCGET" > defaults/autostart
+
+EXPOSE 3001
+
+volume /CONFIG


### PR DESCRIPTION
Uses linuxserver.io's base image, allows the program to be utilised without a screen (ie on a server).

Simply build image, run it, then connect via {ip}:3001 (skipping the self-signed cert error). Could add a github workflow to push the image each release for people to use if they're using this on a server

Close if unwanted feature

The version number in the curl URL would need to be maintained. The /latest/ path works, but because files have the version number in them it changes each release.