### PR TITLE
chore: Fix grammar in toast messages

### DIFF
--- a/src/components/library/edit-lyrics/PublishLyrics.vue
+++ b/src/components/library/edit-lyrics/PublishLyrics.vue
@@ -138,7 +138,7 @@ const publishLyrics = async () => {
       plainLyrics,
       syncedLyrics
     })
-    toast.success('Your lyrics has been published successfully! It might take up to 24 hours to be visible on the search results.')
+    toast.success('Your lyrics have been published successfully! It might take up to 24 hours to be visible on the search results.')
   } catch (error) {
     isError.value = true
     console.error(error)

--- a/src/components/library/my-lrclib/EditLyrics.vue
+++ b/src/components/library/my-lrclib/EditLyrics.vue
@@ -70,7 +70,7 @@
           <AsyncCodemirror
             v-if="shouldLoadCodeMirror"
             v-model="unifiedLyrics"
-            placeholder="Lyrics is currently empty"
+            placeholder="Lyrics are currently empty"
             class="codemirror-custom h-full outline-none"
             :autofocus="true"
             :indent-with-tab="true"


### PR DESCRIPTION
In English, 'lyrics' is plural, so these toast messages should use plural verbs, like 'have' and 'are'. These messages use a singular verb.