### PR TITLE
fix(edit): Ignore id tags when calculating highlighted line in edit view

### DIFF
--- a/src/components/library/EditLyrics.vue
+++ b/src/components/library/EditLyrics.vue
@@ -318,8 +318,6 @@ const lyricsUpdated = (newLyrics) => {
   isDirty.value = true
   lyricsLintResult.value = executeLyricsLint(newLyrics)
   plainTextLintResult.value = executePlainTextLint(newLyrics)
-  
-  // Clear line mapping cache on document change
   indexToLineCache.value.clear()
 }
 
@@ -337,15 +335,14 @@ const findDocumentLineForLyricIndex = (targetLyricIndex) => {
   const searchFrom = startLineNumber ? startLineNumber + 1 : 1
   let currentLyricIndex = startLineNumber ? startLyricIndex + 1 : 0
   
-  // Search through document lines starting from searchFrom
   for (let lineNum = searchFrom; lineNum <= view.state.doc.lines; lineNum++) {
     const line = view.state.doc.line(lineNum)
     const parsed = parseLine(line.text)
     
-    // Only count TIME lines (skip INFO and INVALID lines)
+    // Only count TIME lines
     if (parsed.type === 'TIME') {
       if (currentLyricIndex === targetLyricIndex) {
-        // Found it! Cache and return the document line number
+        // Cache the document line number before returning
         indexToLineCache.value.set(targetLyricIndex, lineNum)
         return lineNum
       }
@@ -353,7 +350,6 @@ const findDocumentLineForLyricIndex = (targetLyricIndex) => {
     }
   }
   
-  // Not found
   return null
 }
 
@@ -627,7 +623,6 @@ watch(progress, (newProgress) => {
   currentIndex.value = resultCurrentIndex
 
   if (currentIndex.value >= 0) {
-    // Use memoized search to find the actual document line for this lyric index
     const documentLineNum = findDocumentLineForLyricIndex(currentIndex.value)
     if (documentLineNum && documentLineNum <= view.state.doc.lines) {
       const line = view.state.doc.line(documentLineNum)

--- a/src/components/library/EditLyrics.vue
+++ b/src/components/library/EditLyrics.vue
@@ -171,6 +171,7 @@ const plainTextLintResult = ref([])
 const cmContainer = ref(null)
 const cmHeight = ref(null)
 const currentIndex = ref(null)
+const indexToLineCache = ref(new Map())
 
 let view = null
 let runner = null
@@ -317,6 +318,38 @@ const lyricsUpdated = (newLyrics) => {
   isDirty.value = true
   lyricsLintResult.value = executeLyricsLint(newLyrics)
   plainTextLintResult.value = executePlainTextLint(newLyrics)
+  
+  // Clear line mapping cache on document change
+  indexToLineCache.value.clear()
+}
+
+const findDocumentLineForLyricIndex = (targetLyricIndex) => {
+  // Check if we have a cached position for the previous lyric index
+  const startLyricIndex = targetLyricIndex - 1
+  const startLineNumber = indexToLineCache.value.get(startLyricIndex)
+  
+  // Start search from cached position + 1, or from beginning if no cache
+  const searchFrom = startLineNumber ? startLineNumber + 1 : 1
+  let currentLyricIndex = startLineNumber ? startLyricIndex + 1 : 0
+  
+  // Search through document lines starting from searchFrom
+  for (let lineNum = searchFrom; lineNum <= view.state.doc.lines; lineNum++) {
+    const line = view.state.doc.line(lineNum)
+    const parsed = parseLine(line.text)
+    
+    // Only count TIME lines (skip INFO and INVALID lines)
+    if (parsed.type === 'TIME') {
+      if (currentLyricIndex === targetLyricIndex) {
+        // Found it! Cache and return the document line number
+        indexToLineCache.value.set(targetLyricIndex, lineNum)
+        return lineNum
+      }
+      currentLyricIndex++
+    }
+  }
+  
+  // Not found
+  return null
 }
 
 const syncLine = (moveNext = true) => {
@@ -589,8 +622,12 @@ watch(progress, (newProgress) => {
   currentIndex.value = resultCurrentIndex
 
   if (currentIndex.value >= 0) {
-    const line = view.state.doc.line(currentIndex.value + 1)
-    view.dispatch({ effects: addLineHighlight.of(line.from) })
+    // Use memoized search to find the actual document line for this lyric index
+    const documentLineNum = findDocumentLineForLyricIndex(currentIndex.value)
+    if (documentLineNum) {
+      const line = view.state.doc.line(documentLineNum)
+      view.dispatch({ effects: addLineHighlight.of(line.from) })
+    }
   } else {
     view.dispatch({ effects: addLineHighlight.of(null) })
   }

--- a/src/components/library/EditLyrics.vue
+++ b/src/components/library/EditLyrics.vue
@@ -326,7 +326,12 @@ const lyricsUpdated = (newLyrics) => {
 const findDocumentLineForLyricIndex = (targetLyricIndex) => {
   // Check if we have a cached position for the previous lyric index
   const startLyricIndex = targetLyricIndex - 1
-  const startLineNumber = indexToLineCache.value.get(startLyricIndex)
+  const cachedLineNumber = indexToLineCache.value.get(startLyricIndex)
+  
+  // Validate cached line number is still within document bounds
+  const startLineNumber = (cachedLineNumber && cachedLineNumber <= view.state.doc.lines) 
+    ? cachedLineNumber 
+    : null
   
   // Start search from cached position + 1, or from beginning if no cache
   const searchFrom = startLineNumber ? startLineNumber + 1 : 1
@@ -624,7 +629,7 @@ watch(progress, (newProgress) => {
   if (currentIndex.value >= 0) {
     // Use memoized search to find the actual document line for this lyric index
     const documentLineNum = findDocumentLineForLyricIndex(currentIndex.value)
-    if (documentLineNum) {
+    if (documentLineNum && documentLineNum <= view.state.doc.lines) {
       const line = view.state.doc.line(documentLineNum)
       view.dispatch({ effects: addLineHighlight.of(line.from) })
     }


### PR DESCRIPTION
## Background

The EditLyrics view naively calculates the line to highlight without taking into consideration if lines are not a timed lyric line (such as ID tags like `[lang: <language>]` or an empty newline). This causes a mismatch during playback if there are any non-time lines in the document. 

The non-edit view pre-parses the document to strip out display ID tags and so does not have the same problem.

<img width="766" height="381" alt="Screenshot From 2026-01-27 22-30-22" src="https://github.com/user-attachments/assets/e70f5263-df5e-47c0-821a-112412a1de8b" />

Note that the ID tag is incorrectly highlighted when playback has already progressed past the first lyric line's timestamp.

## Implementation

* Switches the highlighting logic to map lyric numbers to line numbers within the lyric document
* Caches the line mapping, which resets on document change.