### PR TITLE
fix(library): Upgrade lofty version

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2", features = [ "protocol-asset", "devtools"] }
 globwalk = "0.9.1"
 reqwest = { version = "0.12.7", features = ["json"] }
-lofty = "0.21.1"
+lofty = "0.22.0"
 anyhow = "1.0.89"
 thiserror = "1.0"
 rusqlite = { version = "0.32.1", features = ["bundled"] }


### PR DESCRIPTION
Was having issues with some files being read in due to a separator issue, issue was resolved in v0.22.0, so upgraded library from v0.21.1 to v0.22.0