### PR TITLE
Use filename as title when metadata is missing

### DIFF
--- a/src-tauri/src/scanner/metadata.rs
+++ b/src-tauri/src/scanner/metadata.rs
@@ -67,8 +67,12 @@ impl TrackMetadata {
 
         // Extract required fields
         let title = tag
-            .title()
-            .ok_or_else(|| MetadataError::MissingField {
+            .title().or_else(|| {
+								match path.file_name() {
+										Some(n) => return Some(n.to_string_lossy()),
+										None => return None,
+								};
+						}).ok_or_else(|| MetadataError::MissingField {
                 field: "title".to_string(),
                 path: file_path.clone(),
             })?


### PR DESCRIPTION
Some tools like yt-dlp don't (or don't always) download metadata for files. This adds the file's name as the title as a default when there's no entry for it in the metadata. I considered adding it for the other fields as well, but couldn't come up with a sensible default outside of some sort of special "none" value.