### PR TITLE
feat: improves word-by-word sync and the shortcut system

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src-tauri/ARCHITECTURE.md
+++ b/src-tauri/ARCHITECTURE.md
@@ -166,7 +166,7 @@ struct Player {
     sound_handle: Option<StreamingSoundHandle>,
     track: Option<PlayableTrack>,      // Unified type for DB and file-based tracks
     status: PlayerStatus,               // Playing/Paused/Stopped
-    progress: f64, duration: f64, volume: f64,
+    progress: f64, duration: f64, volume: f64, playback_speed: f64,
 }
 ```
 
@@ -178,6 +178,11 @@ Volume persistence:
 - Player initializes with volume from `config_data` on startup
 - `set_volume()` command updates both the player and persists to config
 - Frontend receives volume updates via `player-state` events
+
+Playback speed:
+- Player tracks current `playback_speed` and reapplies it when a new track starts
+- `set_playback_speed()` command updates the active sound handle rate (clamped 0.5x–2.0x)
+- Frontend receives playback speed via `player-state` events
 
 ### Export Module (`export.rs`)
 
@@ -307,7 +312,7 @@ Search across all three entity types uses SQLite FTS5 (via `tracks_fts`, `albums
 
 ### Playback & Config
 - `play_track(track_id?, file_path?, title?, album_name?, artist_name?, album_artist_name?, duration?)` - Unified playback for both library tracks (via `track_id`) and file-based tracks (via `file_path` with metadata)
-- `pause/resume_track()`, `seek_track()`, `stop_track()`, `set_volume()` (persists volume to config)
+- `pause/resume_track()`, `seek_track()`, `stop_track()`, `set_volume()` (persists volume to config), `set_playback_speed()`
 - `get/set_directories()`, `get/set_config()`, `get_init()`
 - Volume is loaded from config on startup and auto-saved when changed via `set_volume()`
 - `open_devtools()`, `drain_notifications()`

--- a/src-tauri/ARCHITECTURE.md
+++ b/src-tauri/ARCHITECTURE.md
@@ -14,7 +14,9 @@
 | Scanning | Single-pass streaming with batch processing (100 files) |
 | Export | Manual sidecar (.txt/.lrc) and embedded metadata export |
 
-**Key Dependencies:** `tauri`, `rusqlite`+`rusqlite_migration`, `lofty`, `kira`, `reqwest`, `rayon`, `xxhash-rust`, `regex` (for LRC parsing)
+**Key Dependencies:** `tauri`, `rusqlite`+`rusqlite_migration`, `lofty`, `kira`, `reqwest`, `rayon`, `xxhash-rust`, `regex` (for LRC parsing), `charabia` (international word segmentation)
+
+**Word Segmentation Command:** `segment_words(text)` in `main.rs` uses Charabia's segmenter (`Segment::segment_str`) and then applies language-agnostic post-processing: segments containing at least one letter/number are kept as tokens, while separator-only segments (spaces/punctuation/symbols) are merged into adjacent tokens.
 
 ## Project Structure
 
@@ -32,6 +34,7 @@ src-tauri/
 │   │   └── models.rs        # ScanResult, ScanProgress
 │   ├── parser/              # File format parsers
 │   │   └── lrc.rs           # LRC lyrics parser (replaces lrc crate)
+│   ├── word_segmentation.rs # Charabia-based tokenization + separator-merging logic/tests
 │   ├── export.rs            # Manual sidecar/embed export helpers
 │   ├── lyricsfile.rs        # YAML lyricsfile helpers
 │   ├── player.rs            # Kira audio playback

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +58,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
@@ -184,6 +196,26 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bitflags"
@@ -365,7 +397,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cedarwood"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -406,6 +449,26 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "charabia"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51689ee7cc84c8de789fc2874711d816055b93406cfd4135c40d1c82dd24b928"
+dependencies = [
+ "aho-corasick",
+ "csv",
+ "either",
+ "fst",
+ "irg-kvariants",
+ "jieba-rs",
+ "lindera",
+ "serde",
+ "slice-group-by",
+ "unicode-normalization",
+ "wana_kana",
+ "whatlang",
+]
 
 [[package]]
 name = "chrono"
@@ -663,6 +726,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,12 +758,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -698,14 +806,31 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "dasp_sample"
@@ -727,6 +852,37 @@ checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -888,12 +1044,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -993,6 +1222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1264,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1076,6 +1321,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futf"
@@ -1305,8 +1556,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1316,9 +1569,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1569,6 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1577,7 +1833,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1585,6 +1841,11 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1707,6 +1968,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1929,6 +2191,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e233413926ef735f7d87024466cfda5a4b87467730846bd82ea7d504121347"
+dependencies = [
+ "include-flate-codegen",
+ "include-flate-compress",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7148f24ef8922cc0e5574ebb908729ccdd3a110c440a45165733fedadd9969"
+dependencies = [
+ "include-flate-compress",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74783a9ed407e844e99d5e7a57bd650acbfa124cf6e97ffd790ba59d8ab8e7ff"
+dependencies = [
+ "libflate",
+ "zstd",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2298,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "irg-kvariants"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2af7c331f2536964a32b78a7d2e0963d78b42f4a76323b16cc7d94b1ddce26"
+dependencies = [
+ "csv",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "iri-string"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2335,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2061,6 +2376,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "jieba-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348294e44ee7e3c42685da656490f8febc7359632544019621588902216da95c"
+dependencies = [
+ "phf_codegen 0.13.1",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "766bd7012aa5ba49411ebdf4e93bddd59b182d2918e085d58dec5bb9b54b7105"
+dependencies = [
+ "cedarwood",
+ "include-flate",
+ "jieba-macros",
+ "phf 0.13.1",
+ "regex",
+ "rustc-hash",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2419,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2114,6 +2462,15 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2193,6 +2550,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libflate"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.0",
+ "no_std_io2",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2602,129 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lindera"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877750979d709bb5fb2d616a2c9968301ead80147db2270c8f23d8239467f159"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "csv",
+ "kanaria",
+ "lindera-cc-cedict",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "lindera-ipadic-neologd",
+ "lindera-ko-dic",
+ "lindera-unidic",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum",
+ "strum_macros",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "yada",
+]
+
+[[package]]
+name = "lindera-cc-cedict"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efb27e037efbd41fdce30e3771084a46040cdfdbec718425879f8aa7dfa16f2"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbb45e81527092e1af24c45bf068376df34faaa9f98d44a99ec59c7edfdb45a"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "csv",
+ "derive_builder",
+ "encoding",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "once_cell",
+ "rand 0.9.4",
+ "reqwest 0.12.23",
+ "serde",
+ "tar",
+ "thiserror 2.0.16",
+ "tokio",
+ "yada",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447887ebb06c9faf7e9b41c03b491ae3e12aca2c0e119a865b682863a1b538aa"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic-neologd"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da7829c17dee5b1068f241c1989f83a2d98307ed5d3b87fcc91bd06b7a7b44e"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ko-dic"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc88354c6f8fbdeb7aa3d44673eb0ca03b7ad6e8d4edb62332604bb7806d17b"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-unidic"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf374587e0202193c73f443cb0ba0d34ff0013949b2355aeeeb0f840679681e"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "lindera-dictionary",
+ "once_cell",
+ "tokio",
 ]
 
 [[package]]
@@ -2282,6 +2786,7 @@ name = "lrcget"
 version = "2.1.0"
 dependencies = [
  "anyhow",
+ "charabia",
  "collapse",
  "data-encoding",
  "globwalk",
@@ -2311,6 +2816,12 @@ dependencies = [
  "tokio",
  "xxhash-rust",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2357,6 +2868,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2489,6 +3006,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nodrop"
@@ -2991,6 +3517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,6 +3544,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3038,6 +3584,16 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3090,6 +3646,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -3235,6 +3800,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,6 +3867,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,6 +3962,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3992,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +4017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -3494,6 +4165,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3501,6 +4174,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3508,6 +4182,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3583,6 +4258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rtrb"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +4301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +4335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3660,6 +4348,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3960,7 +4649,7 @@ version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4094,6 +4783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4888,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "subtle"
@@ -4538,6 +5254,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5348,6 +6075,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5379,6 +6112,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -5447,6 +6186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "vswhom"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5474,6 +6219,17 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wana_kana"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74666202acfcb4f9b995be2e3e9f7f530deb65e05a1407b8d0b30c9c451238a"
+dependencies = [
+ "fnv",
+ "itertools",
+ "lazy_static",
 ]
 
 [[package]]
@@ -5664,6 +6420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,6 +6474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5748,6 +6523,16 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whatlang"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471d1c1645d361eb782a1650b1786a8fb58dd625e681a04c09f5ff7c8764a7b0"
+dependencies = [
+ "hashbrown 0.14.5",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"
@@ -6336,6 +7121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6346,6 +7141,12 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yada"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed111bd9e48a802518765906cbdadf0b45afb72b9c81ab049a3b86252adffdd"
 
 [[package]]
 name = "yoke"
@@ -6449,6 +7250,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ data-encoding = "2.4.0"
 kira = "0.12.0"
 symphonia = { version = "0.5.4", features = ["all"] }
 regex = "1.10.4"
+charabia = "0.9.9"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 tauri-plugin-os = "2.3.2"
 tauri-plugin-shell = "2.3.5"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ pub mod player;
 pub mod scanner;
 pub mod state;
 pub mod utils;
+pub mod word_segmentation;
 
 use persistent_entities::{PersistentAlbum, PersistentArtist, PersistentConfig, PersistentTrack, PlayableTrack};
 use player::Player;
@@ -1472,6 +1473,11 @@ async fn read_text_file(file_path: String) -> Result<String, String> {
         .map_err(|err| format!("Failed to read file: {}", err))
 }
 
+#[tauri::command]
+async fn segment_words(text: String) -> Result<Vec<String>, String> {
+    Ok(word_segmentation::segment_words_for_timing(text.as_str()))
+}
+
 #[tokio::main]
 async fn main() {
     tauri::Builder::default()
@@ -1592,6 +1598,7 @@ async fn main() {
             prepare_lrclib_lyricsfile,
             refresh_lrclib_lyricsfile,
             read_text_file,
+            segment_words,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1441,6 +1441,17 @@ fn set_volume(
 }
 
 #[tauri::command]
+fn set_playback_speed(playback_speed: f64, app_state: tauri::State<AppState>) -> Result<(), String> {
+    let mut player_guard = app_state.player.lock().map_err(|e| e.to_string())?;
+
+    if let Some(ref mut player) = *player_guard {
+        player.set_playback_speed(playback_speed);
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
 fn open_devtools(app_handle: AppHandle) {
     app_handle
         .get_webview_window("main")
@@ -1572,6 +1583,7 @@ async fn main() {
             seek_track,
             stop_track,
             set_volume,
+            set_playback_speed,
             open_devtools,
             drain_notifications,
             find_matching_tracks,

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -30,6 +30,7 @@ pub struct Player {
     pub progress: f64,
     pub duration: f64,
     pub volume: f64,
+    pub playback_speed: f64,
 }
 
 impl Player {
@@ -44,6 +45,7 @@ impl Player {
             progress: 0.0,
             duration: 0.0,
             volume: initial_volume,
+            playback_speed: 1.0,
         })
     }
 
@@ -83,6 +85,10 @@ impl Player {
                 .as_mut()
                 .unwrap()
                 .set_volume(Self::volume_as_decibels(self.volume), Tween::default());
+            self.sound_handle
+                .as_mut()
+                .unwrap()
+                .set_playback_rate(self.playback_speed, Tween::default());
         }
 
         Ok(())
@@ -146,6 +152,16 @@ impl Player {
             sound_handle.set_volume(Self::volume_as_decibels(volume), Tween::default());
         }
         self.volume = volume;
+    }
+
+    pub fn set_playback_speed(&mut self, playback_speed: f64) {
+        let clamped_speed = playback_speed.clamp(0.5, 2.0);
+
+        if let Some(ref mut sound_handle) = self.sound_handle {
+            sound_handle.set_playback_rate(clamped_speed, Tween::default());
+        }
+
+        self.playback_speed = clamped_speed;
     }
 }
 

--- a/src-tauri/src/word_segmentation.rs
+++ b/src-tauri/src/word_segmentation.rs
@@ -1,0 +1,203 @@
+use charabia::Segment;
+
+pub fn segment_words_for_timing(text: &str) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let raw_segments: Vec<String> = text
+        .segment_str()
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_owned)
+        .collect();
+
+    merge_segment_tokens(raw_segments)
+}
+
+fn merge_segment_tokens(raw_segments: Vec<String>) -> Vec<String> {
+    // Charabia can emit standalone whitespace/punctuation for some texts.
+    // Merge those separators with neighboring word tokens so timing lanes do not
+    // create standalone "word" blocks for spaces or punctuation.
+    let mut merged_tokens: Vec<String> = Vec::new();
+    let mut pending_prefix = String::new();
+
+    let mut index = 0;
+    while index < raw_segments.len() {
+        let segment = &raw_segments[index];
+        let is_separator_only = segment
+            .chars()
+            .all(|ch| ch.is_whitespace() || !ch.is_alphanumeric());
+
+        if is_separator_only {
+            let has_prev_word = merged_tokens
+                .last()
+                .is_some_and(|token| token.chars().any(char::is_alphanumeric));
+            let next_is_word = raw_segments
+                .get(index + 1)
+                .is_some_and(|next| next.chars().any(char::is_alphanumeric));
+
+            // Keep contractions like don't / can't / l'amour as a single token.
+            if is_apostrophe_connector(segment) && has_prev_word && next_is_word {
+                if let Some(last) = merged_tokens.last_mut() {
+                    last.push_str(segment);
+                    index += 1;
+                    last.push_str(&raw_segments[index]);
+                }
+                index += 1;
+                continue;
+            }
+
+            // Opening brackets should prefix the next token, not suffix the previous one.
+            if is_opening_bracket_connector(segment) && next_is_word {
+                pending_prefix.push_str(segment);
+                index += 1;
+                continue;
+            }
+
+            if let Some(last) = merged_tokens.last_mut() {
+                last.push_str(segment);
+            } else {
+                pending_prefix.push_str(segment);
+            }
+            index += 1;
+            continue;
+        }
+
+        if pending_prefix.is_empty() {
+            merged_tokens.push(segment.to_owned());
+        } else {
+            let mut combined = pending_prefix.clone();
+            combined.push_str(segment);
+            merged_tokens.push(combined);
+            pending_prefix.clear();
+        }
+
+        index += 1;
+    }
+
+    if !pending_prefix.is_empty() {
+        if let Some(last) = merged_tokens.last_mut() {
+            last.push_str(&pending_prefix);
+        } else {
+            merged_tokens.push(pending_prefix);
+        }
+    }
+
+    merged_tokens
+}
+
+fn is_apostrophe_connector(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment.chars().all(|ch| matches!(ch, '\'' | '’' | 'ʼ'))
+}
+
+fn is_opening_bracket_connector(segment: &str) -> bool {
+    let mut has_open_bracket = false;
+
+    for ch in segment.chars() {
+        if ch.is_whitespace() {
+            continue;
+        }
+
+        if matches!(
+            ch,
+            '('
+                | '['
+                | '{'
+                | '<'
+                | '（'
+                | '［'
+                | '｛'
+                | '〈'
+                | '《'
+                | '「'
+                | '『'
+                | '【'
+                | '〔'
+                | '〖'
+                | '〘'
+                | '〚'
+                | '⟨'
+                | '⟪'
+                | '⟮'
+                | '⦗'
+                | '⸢'
+        ) {
+            has_open_bracket = true;
+            continue;
+        }
+
+        return false;
+    }
+
+    has_open_bracket
+}
+
+#[cfg(test)]
+mod tests {
+    use super::segment_words_for_timing;
+
+    fn contains_alnum(text: &str) -> bool {
+        text.chars().any(char::is_alphanumeric)
+    }
+
+    fn is_separator_only(text: &str) -> bool {
+        text.chars()
+            .all(|ch| ch.is_whitespace() || !ch.is_alphanumeric())
+    }
+
+    fn assert_segmentation_invariants(text: &str) {
+        let merged = segment_words_for_timing(text);
+        let reconstructed = merged.concat();
+
+        assert_eq!(
+            reconstructed, text,
+            "Merged tokens must reconstruct original input"
+        );
+
+        if contains_alnum(text) {
+            assert!(
+                merged.iter().all(|token| !is_separator_only(token)),
+                "No separator-only tokens should remain when text contains word characters"
+            );
+        }
+    }
+
+    #[test]
+    fn english_with_punctuation_and_spaces_has_no_separator_tokens() {
+        assert_segmentation_invariants("Hello, world!  It's me.");
+    }
+
+    #[test]
+    fn japanese_text_preserves_reconstruction() {
+        assert_segmentation_invariants("今日は、世界！ テスト中です。");
+    }
+
+    #[test]
+    fn arabic_text_preserves_reconstruction() {
+        assert_segmentation_invariants("مرحبا، بالعالم! كيف الحال؟");
+    }
+
+    #[test]
+    fn mixed_emoji_and_symbols_preserves_reconstruction() {
+        assert_segmentation_invariants("Hi 👋 -- version 2.0 (beta) ✨");
+    }
+
+    #[test]
+    fn english_contractions_remain_single_tokens() {
+        let merged = segment_words_for_timing("don't can't won't");
+        assert_eq!(merged, vec!["don't ", "can't ", "won't"]);
+    }
+
+    #[test]
+    fn curly_apostrophe_contractions_remain_single_tokens() {
+        let merged = segment_words_for_timing("don’t can’t l’amour");
+        assert_eq!(merged, vec!["don’t ", "can’t ", "l’amour"]);
+    }
+
+    #[test]
+    fn opening_brackets_attach_to_next_token() {
+        let merged = segment_words_for_timing("hello (world) [test] {ok}");
+        assert_eq!(merged, vec!["hello ", "(world) ", "[test] ", "{ok}"]);
+    }
+}

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -113,6 +113,12 @@ Shortcut behavior and shortcut-menu content share one canonical registry:
 - Runtime handlers consume that registry: `useEditLyricsV2Hotkeys.js`, `useEditLyricsV2SyncedHotkeys.js`, `useEditLyricsV2WordTimingHotkeys.js`
 - Menu data (`keyboardShortcuts.js`) is derived from the same registry
 - Result: shortcut behavior and displayed shortcut menu stay in sync
+- Shortcut-aware button tooltips are also derived from the same registry (e.g., `Sync line to current playback (Space)`)
+- Shortcuts are configurable via registry override APIs (`setShortcutOverride`, `resetShortcutOverride`, `resetAllShortcutOverrides`) and persisted in browser `localStorage`
+- `KeyboardShortcutsModal.vue` includes a Configure mode window to remap shortcuts by key capture and reset per-shortcut or all shortcuts
+- Configure mode detects duplicate shortcut assignments and shows warnings both globally and per conflicting shortcut
+- Configure mode shows capture/result feedback through button color states (listening, assigned, canceled, reset)
+- Modified shortcuts (customized from defaults) are highlighted via key chip and reset-button colors
 - Access: header keyboard icon and `Ctrl+/` open `KeyboardShortcutsModal.vue`
 
 Utils: `src/utils/` (parsing, linting), Composables: `composables/edit-lyrics-v2/`, `composables/export.js`. Default word timing tokenization uses backend `segment_words` (Charabia), with frontend tokenizer fallback.

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -127,7 +127,7 @@ Utils: `src/utils/` (parsing, linting), Composables: `composables/edit-lyrics-v2
 
 ## Technical Details
 
-**Styling**: Tailwind CSS + custom classes in `style.css`. Primary accent palette (`hoa`) from `tailwind.config.cjs`. Structural colors (backgrounds, text, borders) use Tailwind's default `neutral` scale. Dark mode via `html.dark`. Semantic classes: `.button`, `.input`, `.modal-content`, `.link`.
+**Styling**: Tailwind CSS + custom classes in `style.css`. Primary accent palette (`hoa`) from `tailwind.config.cjs`. Structural colors (backgrounds, text, borders) use Tailwind's default `neutral` scale. Dark mode via `html.dark`. Semantic classes: `.button`, `.input`, `.select`, `.modal-content`, `.link`.
 
 **Icons**: Icons are imported directly per-file from `~icons/mdi/*` (powered by `unplugin-icons` in `vite.config.js`). Avoid adding `mdue`; use MDI icon imports instead.
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -82,13 +82,40 @@ Module-level ref composables (singletons by design):
 | **Display** | `LyricsViewer.vue` (synced) / `PlainLyricsViewer.vue`. Click to `seek()` |
 | **Search** | `SearchLyrics.vue` + `Preview.vue` for LRCLIB lookup; word-level highlight when available |
 | **Normalization** | `normalizeLrclibLyrics()` derives plain/synced/instrumental from `lyricsfile` when LRCLIB omits direct fields |
-| **Edit/Publish** | `EditLyricsV2.vue` — CodeMirror + synced view + word timing lane. Props: `audioSource` (playback), `lyricsfile` (editing), `trackId` (save behavior). Instrumental toggle via `PlainLyricsEmptyState.vue`/`SyncedLyricsEmptyState.vue`. Publish logic in `useEditLyricsV2Publish.js`, export in `useEditLyricsV2Export.js`. Synced tab supports multi-line selection via drag and Ctrl/Cmd+click, with a floating toolbar for bulk rewind/forward/delete |
-| **Keyboard Shortcuts** | `KeyboardShortcutsModal.vue` (full reference modal via `BaseModal`). Definitions in `composables/edit-lyrics-v2/keyboardShortcuts.js`. Header keyboard icon opens the modal |
+| **Edit/Publish** | `EditLyricsV2.vue` + `useEditLyricsV2Publish.js` + `useEditLyricsV2Export.js`. For detailed editor behavior, see **Edit/Publish Details** below. |
+| **Keyboard Shortcuts** | `KeyboardShortcutsModal.vue` + shared registry in `composables/edit-lyrics-v2/shortcutRegistry.js`. See **Keyboard Shortcuts Details** below. |
 | **Mass Export** | `LibraryHeader.vue` → `ExportViewer.vue` → `useExporter()` queue → `export_track_lyrics` per track |
 | **My LRCLIB** | User workflows (preview, edit, publish, flag) in `my-lrclib/` |
 | **Track Association** | My LRCLIB edit flow: `prepare_lrclib_lyricsfile()` → `AssociateTrackModal.vue` → `EditLyricsV2.vue` with `trackId: null` (temporary association only) |
 
-Utils: `src/utils/` (parsing, linting), Composables: `composables/edit-lyrics-v2/`, `composables/export.js`
+### Edit/Publish Details
+
+`EditLyricsV2.vue` combines CodeMirror plain editing and synced editing with a word timing lane.
+
+- Props/context: `audioSource` (playback source), `lyricsfile` (editing target), `trackId` (save behavior)
+- Instrumental mode: toggle via `PlainLyricsEmptyState.vue` / `SyncedLyricsEmptyState.vue`
+- Publish/export: handled by `useEditLyricsV2Publish.js` and `useEditLyricsV2Export.js`
+- Synced lines: multi-line selection via drag and Ctrl/Cmd+click, with floating bulk rewind/forward/delete toolbar
+- Player bar: playback speed control (`0.5x`-`2.0x`)
+- Line status: each synced line row shows a tiny word-sync status dot
+- Word timing: multi-separator selection (Ctrl/Cmd+click + Shift+click), merge separators (`Delete`/`Backspace`), hover split preview snapped to grapheme boundaries, double-click split at cursor, and `Z` syncs selected separator then advances (last-word sync advances to next line)
+- Narrow segment hint: when a segment is too narrow to show text, a visible hint is rendered beneath it with the next word text
+- Boundary sync: can cascade adjacent boundaries so sync is not blocked by intervening separators, while staying within line bounds
+- Reset behavior: clears persisted word timings and reloads default (non-persisted) segmentation
+- Line-start sync behavior: syncing line start shifts existing word boundaries by the same offset
+- Selection behavior: selecting a synced line starts at the second boundary by default
+
+### Keyboard Shortcuts Details
+
+Shortcut behavior and shortcut-menu content share one canonical registry:
+
+- Definitions live in `composables/edit-lyrics-v2/shortcutRegistry.js`
+- Runtime handlers consume that registry: `useEditLyricsV2Hotkeys.js`, `useEditLyricsV2SyncedHotkeys.js`, `useEditLyricsV2WordTimingHotkeys.js`
+- Menu data (`keyboardShortcuts.js`) is derived from the same registry
+- Result: shortcut behavior and displayed shortcut menu stay in sync
+- Access: header keyboard icon and `Ctrl+/` open `KeyboardShortcutsModal.vue`
+
+Utils: `src/utils/` (parsing, linting), Composables: `composables/edit-lyrics-v2/`, `composables/export.js`. Default word timing tokenization uses backend `segment_words` (Charabia), with frontend tokenizer fallback.
 
 ## Technical Details
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -57,7 +57,7 @@ Module-level ref composables (singletons by design):
 
 - `ChooseDirectory.vue` - Setup: folder picker, persists via `set_directories`, emits to trigger library view
 - `Library.vue` - Header + tabbed panes (Tracks/Albums/Artists/MyLrclib) + `NowPlaying.vue`. Manages scan lifecycle (`scan-progress`, `scan-complete`, `scan_library`)
-- `NowPlaying.vue` - Persistent bottom panel. Track metadata, seek/play/volume, lyrics. Keyboard shortcuts (space/enter/arrows) disabled when typing or via `isHotkey` state
+- `NowPlaying.vue` - Persistent bottom panel. Track metadata, seek/play/volume/speed, lyrics. Keyboard shortcuts (space/enter/arrows) disabled when typing or via `isHotkey` state
 
 **Modals**: `Config.vue`, `About.vue`, `DownloadViewer.vue`
 

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -96,6 +96,8 @@ Module-level ref composables (singletons by design):
 - Instrumental mode: toggle via `PlainLyricsEmptyState.vue` / `SyncedLyricsEmptyState.vue`
 - Publish/export: handled by `useEditLyricsV2Publish.js` and `useEditLyricsV2Export.js`
 - Synced lines: multi-line selection via drag and Ctrl/Cmd+click, with floating bulk rewind/forward/delete toolbar
+- Synced line nudge shortcuts: `Left`/`Right` adjust selected line start by `-/+100ms`; `Shift+Left`/`Shift+Right` adjust selected line end by `-/+100ms`
+- End timestamp visibility: in synced rows, the end timestamp pill stays visible even without hover when it differs from the next line's start timestamp (helps surface gaps/overlaps), and color-codes direction (`before` = gap, `after` = overlap)
 - Player bar: playback speed control (`0.5x`-`2.0x`)
 - Line status: each synced line row shows a tiny word-sync status dot
 - Word timing: multi-separator selection (Ctrl/Cmd+click + Shift+click), merge separators (`Delete`/`Backspace`), hover split preview snapped to grapheme boundaries, double-click split at cursor, and `Z` syncs selected separator then advances (last-word sync advances to next line)

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -76,7 +76,7 @@
           <label class="flex items-center gap-1 text-xs text-neutral-700 dark:text-neutral-300">
             <span>Speed</span>
             <select
-              class="rounded border border-neutral-300 bg-white px-1.5 py-0.5 text-xs text-neutral-800 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+              class="select select-xs"
               :value="String(playbackSpeed)"
               @change="handleSpeedChange"
             >

--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -72,7 +72,19 @@
           </button>
         </div>
 
-        <div class="basis-1/3 flex-1 flex justify-end items-center">
+        <div class="basis-1/3 flex-1 flex justify-end items-center gap-2">
+          <label class="flex items-center gap-1 text-xs text-neutral-700 dark:text-neutral-300">
+            <span>Speed</span>
+            <select
+              class="rounded border border-neutral-300 bg-white px-1.5 py-0.5 text-xs text-neutral-800 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+              :value="String(playbackSpeed)"
+              @change="handleSpeedChange"
+            >
+              <option v-for="option in speedOptions" :key="option" :value="String(option)">
+                {{ option.toFixed(2).replace(/\.00$/, '') }}x
+              </option>
+            </select>
+          </label>
           <VolumeSlider :volume="volume" @set-volume="setPlayerVolume" />
         </div>
       </div>
@@ -118,12 +130,23 @@ const {
   duration,
   progress,
   volume,
+  playbackSpeed,
   playTrack,
   pause,
   resume,
   seek,
   setVolume: setPlayerVolume,
+  setPlaybackSpeed,
 } = usePlayer()
+
+const speedOptions = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+
+const handleSpeedChange = event => {
+  const value = parseFloat(event.target.value)
+  if (Number.isFinite(value)) {
+    setPlaybackSpeed(value)
+  }
+}
 const keydownEvent = ref(null)
 
 const instrumental = computed(() => {

--- a/src/components/library/EditLyricsV2.vue
+++ b/src/components/library/EditLyricsV2.vue
@@ -438,6 +438,8 @@ const { bindSyncedHotkeys, unbindSyncedHotkeys } = useEditLyricsV2SyncedHotkeys(
   deleteSyncedLine,
   rewindLineBy100: rewindLineTimestampBy100,
   forwardLineBy100: forwardLineTimestampBy100,
+  rewindEndBy100,
+  forwardEndBy100,
   playLineAtOffset,
   playLine,
 })

--- a/src/components/library/EditLyricsV2.vue
+++ b/src/components/library/EditLyricsV2.vue
@@ -65,9 +65,11 @@
           :status="status"
           :duration="duration"
           :progress="progress"
+          :playback-speed="playbackSpeed"
           @play-toggle="resumeOrPlay"
           @pause="pause"
           @seek="seek"
+          @set-playback-speed="setPlaybackSpeed"
         />
       </div>
 
@@ -188,7 +190,18 @@ const props = defineProps({
 const emit = defineEmits(['close'])
 
 const { disableHotkey, enableHotkey } = useGlobalState()
-const { status, duration, progress, playingTrack, playTrack, pause, resume, seek } = usePlayer()
+const {
+  status,
+  duration,
+  progress,
+  playbackSpeed,
+  playingTrack,
+  playTrack,
+  pause,
+  resume,
+  seek,
+  setPlaybackSpeed,
+} = usePlayer()
 const toast = useToast()
 
 // Convert props to refs for composables

--- a/src/components/library/EditLyricsV2.vue
+++ b/src/components/library/EditLyricsV2.vue
@@ -113,6 +113,7 @@
         @update:selected-line-indices="handleUpdateSelectedLineIndices"
         @editing-state-change="setSyncedLineEditingState"
         @play-line="playLine"
+        @play-line-at-offset="handlePlayLineAtOffset"
         @sync-line="syncLineToCurrentProgress"
         @rewind-line="rewindLineBy100"
         @forward-line="forwardLineBy100"
@@ -274,7 +275,7 @@ const { exportLyrics, isExporting } = useEditLyricsV2Export({
   toast,
 })
 
-const { playLine, resumeOrPlay } = useEditLyricsV2Playback({
+const { playLine, playLineAtOffset, resumeOrPlay } = useEditLyricsV2Playback({
   audioSource: audioSourceRef,
   syncedLines,
   progress,
@@ -284,6 +285,10 @@ const { playLine, resumeOrPlay } = useEditLyricsV2Playback({
   resume,
   seek,
 })
+
+const handlePlayLineAtOffset = ({ lineIndex, offsetMs }) => {
+  return playLineAtOffset(lineIndex, offsetMs)
+}
 
 const rewindLineBy100 = lineIndex => {
   rewindLineTimestampBy100(lineIndex)
@@ -425,11 +430,15 @@ const { bindSyncedHotkeys, unbindSyncedHotkeys } = useEditLyricsV2SyncedHotkeys(
   selectedSyncedLineIndex,
   selectedSyncedLineIndices,
   syncedLines,
+  progressMs,
   selectSyncedLine,
   clearSyncedLineSelection,
   syncLineToCurrentProgress,
+  syncEndToCurrentProgress,
+  deleteSyncedLine,
   rewindLineBy100: rewindLineTimestampBy100,
   forwardLineBy100: forwardLineTimestampBy100,
+  playLineAtOffset,
   playLine,
 })
 
@@ -504,6 +513,7 @@ const { bindHotkeys, unbindHotkeys } = useEditLyricsV2Hotkeys({
   saveLyrics,
   changeFontSizeBy: changeCodemirrorFontSizeBy,
   resetFontSize: resetCodemirrorFontSize,
+  openShortcutsModal,
 })
 
 onMounted(() => {

--- a/src/components/library/edit-lyrics-v2/EditLyricsV2PlayerBar.vue
+++ b/src/components/library/edit-lyrics-v2/EditLyricsV2PlayerBar.vue
@@ -21,6 +21,19 @@
     <div class="flex-none w-12 text-xs text-neutral-600 dark:text-neutral-400">
       {{ humanDuration(duration) }}
     </div>
+
+    <label class="flex-none inline-flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
+      <span>Speed</span>
+      <select
+        class="px-2 py-1 rounded border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-900 text-neutral-700 dark:text-neutral-200"
+        :value="String(playbackSpeed)"
+        @change="handleSpeedChange"
+      >
+        <option v-for="option in speedOptions" :key="option" :value="String(option)">
+          {{ option.toFixed(2).replace(/\.00$/, '') }}x
+        </option>
+      </select>
+    </label>
   </div>
 </template>
 
@@ -42,9 +55,22 @@ defineProps({
     type: Number,
     default: 0,
   },
+  playbackSpeed: {
+    type: Number,
+    default: 1.0,
+  },
 })
 
-const emit = defineEmits(['play-toggle', 'pause', 'seek'])
+const emit = defineEmits(['play-toggle', 'pause', 'seek', 'set-playback-speed'])
+
+const speedOptions = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+
+const handleSpeedChange = event => {
+  const value = Number(event.target.value)
+  if (Number.isFinite(value)) {
+    emit('set-playback-speed', value)
+  }
+}
 
 const humanDuration = seconds => {
   const boundedSeconds = seconds || 0

--- a/src/components/library/edit-lyrics-v2/EditLyricsV2PlayerBar.vue
+++ b/src/components/library/edit-lyrics-v2/EditLyricsV2PlayerBar.vue
@@ -25,7 +25,7 @@
     <label class="flex-none inline-flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400">
       <span>Speed</span>
       <select
-        class="px-2 py-1 rounded border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-900 text-neutral-700 dark:text-neutral-200"
+        class="select select-xs"
         :value="String(playbackSpeed)"
         @change="handleSpeedChange"
       >

--- a/src/components/library/edit-lyrics-v2/KeyboardShortcutsModal.vue
+++ b/src/components/library/edit-lyrics-v2/KeyboardShortcutsModal.vue
@@ -7,7 +7,43 @@
     body-class="overflow-auto"
     @close="emit('close')"
   >
-    <div class="flex flex-col gap-5">
+    <div class="flex flex-col gap-5 mx-3">
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-xs text-neutral-500 dark:text-neutral-400">
+          {{ isConfigMode ? 'Press Change, then press the new shortcut' : 'View all shortcuts' }}
+        </span>
+        <div class="flex items-center gap-2">
+          <button
+            class="button button-normal p-1.5 rounded h-7 w-7 inline-flex items-center justify-center"
+            :title="isConfigMode ? 'Done configuring shortcuts' : 'Configure shortcuts'"
+            :aria-label="isConfigMode ? 'Done configuring shortcuts' : 'Configure shortcuts'"
+            @click="isConfigMode = !isConfigMode"
+          >
+            <Check v-if="isConfigMode" class="w-4 h-4" />
+            <Tune v-else class="w-4 h-4" />
+          </button>
+          <button
+            v-if="isConfigMode"
+            class="button button-normal p-1.5 rounded h-7 w-7 inline-flex items-center justify-center"
+            :class="resetAllButtonClass"
+            title="Reset all shortcuts"
+            aria-label="Reset all shortcuts"
+            @click="handleResetAll"
+          >
+            <Restore class="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-if="isConfigMode && duplicateGroups.length > 0"
+        class="rounded-md border border-amber-300/70 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 px-3 py-2"
+      >
+        <p class="text-xs font-medium text-amber-800 dark:text-amber-200">
+          Duplicate shortcuts detected ({{ duplicateGroups.length }}). Conflicting shortcuts are highlighted below.
+        </p>
+      </div>
+
       <div
         v-for="category in shortcutCategories"
         :key="category.id"
@@ -32,17 +68,70 @@
           <div
             v-for="(shortcut, index) in category.shortcuts"
             :key="index"
-            class="flex items-center justify-between gap-4"
+            class="flex items-start justify-between gap-4"
           >
-            <span class="text-sm text-neutral-700 dark:text-neutral-300">{{ shortcut.description }}</span>
-            <div class="flex items-center gap-1 shrink-0">
+            <div class="flex flex-col gap-0.5">
+              <span class="text-sm text-neutral-700 dark:text-neutral-300">{{ shortcut.description }}</span>
               <span
-                v-for="(key, keyIndex) in shortcut.keys"
-                :key="keyIndex"
-                class="inline-flex items-center justify-center px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 font-mono text-xs leading-none min-w-[1.5rem]"
+                v-if="isConfigMode && shortcut.id && hasDuplicateShortcut(shortcut.id)"
+                class="text-xs text-amber-700 dark:text-amber-300"
               >
-                {{ key }}
+                Conflicts with: {{ getDuplicateConflictText(shortcut.id) }}
               </span>
+            </div>
+            <div class="flex items-center gap-2 shrink-0">
+              <div class="flex items-center gap-1">
+                <span
+                  v-for="(key, keyIndex) in shortcut.keys"
+                  :key="keyIndex"
+                  class="inline-flex items-center justify-center px-1.5 py-0.5 rounded border text-neutral-700 dark:text-neutral-300 font-mono text-xs leading-none min-w-[1.5rem]"
+                  :class="
+                    isConfigMode && shortcut.id && hasDuplicateShortcut(shortcut.id)
+                      ? 'bg-amber-100 dark:bg-amber-950/40 border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200'
+                      : shortcut.id && isShortcutModified(shortcut)
+                        ? 'bg-hoa-100 dark:bg-hoa-1200/40 border-hoa-300 dark:border-hoa-800 text-hoa-900 dark:text-hoa-200'
+                      : 'bg-neutral-100 dark:bg-neutral-700 border-neutral-200 dark:border-neutral-600'
+                  "
+                >
+                  {{ key }}
+                </span>
+              </div>
+
+              <template v-if="isConfigMode">
+                <template v-if="shortcut.id">
+                  <button
+                    class="button button-normal p-1 rounded h-6 w-6 inline-flex items-center justify-center"
+                    :class="changeButtonClass(shortcut.id)"
+                    :title="
+                      captureShortcutId === shortcut.id
+                        ? 'Press keys for new shortcut'
+                        : `Change shortcut for ${shortcut.description}`
+                    "
+                    :aria-label="
+                      captureShortcutId === shortcut.id
+                        ? 'Press keys for new shortcut'
+                        : `Change shortcut for ${shortcut.description}`
+                    "
+                    @click="startCapture(shortcut.id)"
+                  >
+                    <Loading v-if="isListeningShortcut(shortcut.id)" class="w-4 h-4 animate-spin" />
+                    <Keyboard v-else class="w-4 h-4" />
+                  </button>
+                  <button
+                    class="button button-normal p-1 rounded h-6 w-6 inline-flex items-center justify-center"
+                    :class="resetButtonClass(shortcut.id, shortcut)"
+                    :title="`Reset shortcut for ${shortcut.description}`"
+                    :aria-label="`Reset shortcut for ${shortcut.description}`"
+                    @click="handleResetShortcut(shortcut.id)"
+                  >
+                    <Restore class="w-4 h-4" />
+                  </button>
+                </template>
+                <template v-else>
+                  <span class="h-6 w-6 inline-block" aria-hidden="true" />
+                  <span class="h-6 w-6 inline-block" aria-hidden="true" />
+                </template>
+              </template>
             </div>
           </div>
         </div>
@@ -52,8 +141,20 @@
 </template>
 
 <script setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import BaseModal from '@/components/common/BaseModal.vue'
-import { shortcutCategories } from '@/composables/edit-lyrics-v2/keyboardShortcuts.js'
+import Tune from '~icons/mdi/tune-variant'
+import Check from '~icons/mdi/check'
+import Restore from '~icons/mdi/restore'
+import Keyboard from '~icons/mdi/keyboard-settings-outline'
+import Loading from '~icons/mdi/loading'
+import { getKeyboardShortcutCategories } from '@/composables/edit-lyrics-v2/keyboardShortcuts.js'
+import {
+  resetAllShortcutOverrides,
+  resetShortcutOverride,
+  setShortcutOverride,
+  shortcutKeysFromKeyboardEvent,
+} from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
 
 const props = defineProps({
   activeTab: {
@@ -63,6 +164,272 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close'])
+
+const isConfigMode = ref(false)
+const captureShortcutId = ref('')
+const refreshVersion = ref(0)
+const shortcutButtonStates = ref({})
+const resetAllButtonState = ref('idle')
+const buttonStateTimeouts = new Map()
+
+const shortcutCategories = computed(() => {
+  refreshVersion.value
+  return getKeyboardShortcutCategories()
+})
+
+const configurableShortcuts = computed(() => {
+  return shortcutCategories.value.flatMap(category =>
+    category.shortcuts
+      .filter(shortcut => typeof shortcut.id === 'string' && shortcut.id.length > 0)
+      .map(shortcut => ({
+        id: shortcut.id,
+        description: shortcut.description,
+        keys: shortcut.keys,
+      }))
+  )
+})
+
+const duplicateGroups = computed(() => {
+  const byCombo = new Map()
+
+  for (const shortcut of configurableShortcuts.value) {
+    const keys = Array.isArray(shortcut.keys) ? shortcut.keys : []
+    if (keys.length === 0) {
+      continue
+    }
+
+    const combo = keys.join('+')
+    const group = byCombo.get(combo) || []
+    group.push(shortcut)
+    byCombo.set(combo, group)
+  }
+
+  return Array.from(byCombo.entries())
+    .filter(([, shortcuts]) => shortcuts.length > 1)
+    .map(([combo, shortcuts]) => ({ combo, shortcuts }))
+})
+
+const duplicateConflictMap = computed(() => {
+  const conflictMap = {}
+
+  for (const group of duplicateGroups.value) {
+    for (const shortcut of group.shortcuts) {
+      conflictMap[shortcut.id] = group.shortcuts
+        .filter(other => other.id !== shortcut.id)
+        .map(other => other.description)
+    }
+  }
+
+  return conflictMap
+})
+
+const hasDuplicateShortcut = shortcutId => {
+  return Array.isArray(duplicateConflictMap.value[shortcutId])
+}
+
+const getDuplicateConflictText = shortcutId => {
+  const conflicts = duplicateConflictMap.value[shortcutId] || []
+  return conflicts.join(', ')
+}
+
+const areShortcutKeysEqual = (firstKeys, secondKeys) => {
+  if (!Array.isArray(firstKeys) || !Array.isArray(secondKeys)) {
+    return false
+  }
+
+  if (firstKeys.length !== secondKeys.length) {
+    return false
+  }
+
+  return firstKeys.every((key, index) => key === secondKeys[index])
+}
+
+const isShortcutModified = shortcut => {
+  if (!shortcut?.id || !Array.isArray(shortcut.keys) || !Array.isArray(shortcut.defaultKeys)) {
+    return false
+  }
+
+  return !areShortcutKeysEqual(shortcut.keys, shortcut.defaultKeys)
+}
+
+const setShortcutButtonState = (shortcutId, buttonType, state, timeoutMs = 0) => {
+  const nextState = {
+    ...(shortcutButtonStates.value[shortcutId] || {}),
+    [buttonType]: state,
+  }
+  shortcutButtonStates.value = {
+    ...shortcutButtonStates.value,
+    [shortcutId]: nextState,
+  }
+
+  const timeoutKey = `${shortcutId}:${buttonType}`
+  const existingTimeout = buttonStateTimeouts.get(timeoutKey)
+  if (existingTimeout) {
+    clearTimeout(existingTimeout)
+    buttonStateTimeouts.delete(timeoutKey)
+  }
+
+  if (timeoutMs > 0) {
+    const timeoutId = setTimeout(() => {
+      const current = shortcutButtonStates.value[shortcutId] || {}
+      shortcutButtonStates.value = {
+        ...shortcutButtonStates.value,
+        [shortcutId]: {
+          ...current,
+          [buttonType]: 'idle',
+        },
+      }
+      buttonStateTimeouts.delete(timeoutKey)
+    }, timeoutMs)
+    buttonStateTimeouts.set(timeoutKey, timeoutId)
+  }
+}
+
+const setResetAllButtonState = (state, timeoutMs = 0) => {
+  resetAllButtonState.value = state
+
+  const timeoutKey = '__reset_all__'
+  const existingTimeout = buttonStateTimeouts.get(timeoutKey)
+  if (existingTimeout) {
+    clearTimeout(existingTimeout)
+    buttonStateTimeouts.delete(timeoutKey)
+  }
+
+  if (timeoutMs > 0) {
+    const timeoutId = setTimeout(() => {
+      resetAllButtonState.value = 'idle'
+      buttonStateTimeouts.delete(timeoutKey)
+    }, timeoutMs)
+    buttonStateTimeouts.set(timeoutKey, timeoutId)
+  }
+}
+
+const changeButtonClass = shortcutId => {
+  const state = shortcutButtonStates.value[shortcutId]?.change || 'idle'
+
+  if (state === 'listening') {
+    return '!bg-hoa-600 !text-white hover:!bg-hoa-700 dark:!bg-hoa-500 hover:dark:!bg-hoa-400 ring-2 ring-hoa-300/80 dark:ring-hoa-500/70'
+  }
+
+  if (state === 'success') {
+    return '!bg-emerald-200 !text-emerald-900 hover:!bg-emerald-300 dark:!bg-emerald-800 dark:!text-emerald-100 hover:dark:!bg-emerald-700'
+  }
+
+  if (state === 'warning') {
+    return '!bg-amber-200 !text-amber-900 hover:!bg-amber-300 dark:!bg-amber-800 dark:!text-amber-100 hover:dark:!bg-amber-700'
+  }
+
+  return ''
+}
+
+const isListeningShortcut = shortcutId => {
+  return (shortcutButtonStates.value[shortcutId]?.change || 'idle') === 'listening'
+}
+
+const resetButtonClass = (shortcutId, shortcut) => {
+  const state = shortcutButtonStates.value[shortcutId]?.reset || 'idle'
+
+  if (state === 'success') {
+    return '!bg-emerald-200 !text-emerald-900 hover:!bg-emerald-300 dark:!bg-emerald-800 dark:!text-emerald-100 hover:dark:!bg-emerald-700'
+  }
+
+  if (isShortcutModified(shortcut)) {
+    return '!bg-hoa-100 !text-hoa-900 hover:!bg-hoa-200 dark:!bg-hoa-1200/40 dark:!text-hoa-200 hover:dark:!bg-hoa-1100/50'
+  }
+
+  return ''
+}
+
+const resetAllButtonClass = computed(() => {
+  if (resetAllButtonState.value === 'success') {
+    return '!bg-emerald-200 !text-emerald-900 hover:!bg-emerald-300 dark:!bg-emerald-800 dark:!text-emerald-100 hover:dark:!bg-emerald-700'
+  }
+
+  return ''
+})
+
+const startCapture = shortcutId => {
+  if (!shortcutId) {
+    return
+  }
+
+  if (captureShortcutId.value === shortcutId) {
+    captureShortcutId.value = ''
+    setShortcutButtonState(shortcutId, 'change', 'warning', 1200)
+    return
+  }
+
+  if (captureShortcutId.value) {
+    setShortcutButtonState(captureShortcutId.value, 'change', 'idle')
+  }
+
+  captureShortcutId.value = shortcutId
+  setShortcutButtonState(shortcutId, 'change', 'listening')
+}
+
+const handleResetShortcut = shortcutId => {
+  if (!shortcutId) {
+    return
+  }
+
+  resetShortcutOverride(shortcutId)
+  if (captureShortcutId.value === shortcutId) {
+    captureShortcutId.value = ''
+  }
+  setShortcutButtonState(shortcutId, 'change', 'idle')
+  setShortcutButtonState(shortcutId, 'reset', 'success', 1400)
+  refreshVersion.value += 1
+}
+
+const handleResetAll = () => {
+  resetAllShortcutOverrides()
+  captureShortcutId.value = ''
+  shortcutButtonStates.value = {}
+  setResetAllButtonState('success', 1400)
+  refreshVersion.value += 1
+}
+
+const handleCaptureKeydown = event => {
+  if (!captureShortcutId.value) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  if (event.key === 'Escape') {
+    const canceledShortcutId = captureShortcutId.value
+    captureShortcutId.value = ''
+    if (canceledShortcutId) {
+      setShortcutButtonState(canceledShortcutId, 'change', 'warning', 1200)
+    }
+    return
+  }
+
+  const keys = shortcutKeysFromKeyboardEvent(event)
+  if (keys.length === 0) {
+    return
+  }
+
+  const currentShortcutId = captureShortcutId.value
+  setShortcutOverride(currentShortcutId, keys)
+  setShortcutButtonState(currentShortcutId, 'change', 'success', 1500)
+  captureShortcutId.value = ''
+  refreshVersion.value += 1
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleCaptureKeydown, true)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleCaptureKeydown, true)
+
+  for (const timeoutId of buttonStateTimeouts.values()) {
+    clearTimeout(timeoutId)
+  }
+  buttonStateTimeouts.clear()
+})
 
 const isCategoryActive = categoryId => {
   if (categoryId === 'global') return true

--- a/src/components/library/edit-lyrics-v2/PlainLyricsCodeEditor.vue
+++ b/src/components/library/edit-lyrics-v2/PlainLyricsCodeEditor.vue
@@ -30,21 +30,21 @@
       <div class="toolbar px-2 py-1 flex items-stretch gap-1">
         <button
           class="button button-normal px-1.5 py-0.5 text-sm rounded-full"
-          title="Zoom out"
+          :title="zoomOutTitle"
           @click="emit('change-font-size', -1)"
         >
           <MagnifyMinus />
         </button>
         <button
           class="button button-normal px-1.5 py-0.5 text-sm rounded-full w-[4.5em]"
-          title="Reset zoom level"
+          :title="zoomResetTitle"
           @click="emit('reset-font-size')"
         >
           {{ (fontSize * 100).toFixed(0) }}%
         </button>
         <button
           class="button button-normal px-1.5 py-0.5 text-sm rounded-full"
-          title="Zoom in"
+          :title="zoomInTitle"
           @click="emit('change-font-size', 1)"
         >
           <MagnifyPlus />
@@ -68,6 +68,10 @@ import PlainLyricsEmptyState from '@/components/library/edit-lyrics-v2/PlainLyri
 import Loading from '~icons/mdi/loading'
 import MagnifyPlus from '~icons/mdi/magnify-plus'
 import MagnifyMinus from '~icons/mdi/magnify-minus'
+import {
+  plainEditorShortcutBindings,
+  withShortcutTitle,
+} from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
 const AsyncCodemirror = defineAsyncComponent(async () => {
   const { Codemirror } = await import('vue-codemirror')
   return Codemirror
@@ -105,6 +109,10 @@ const lyricsProxy = computed({
   get: () => props.modelValue,
   set: value => emit('update:modelValue', value),
 })
+
+const zoomOutTitle = withShortcutTitle('Zoom out', plainEditorShortcutBindings, 'zoomOut')
+const zoomResetTitle = withShortcutTitle('Reset zoom level', plainEditorShortcutBindings, 'zoomReset')
+const zoomInTitle = withShortcutTitle('Zoom in', plainEditorShortcutBindings, 'zoomIn')
 
 const handleResize = () => {
   if (!cmContainer.value) {

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grow overflow-hidden flex flex-col relative">
     <SyncedWordTimingLane
-      class="shrink-0 mt-2"
+      class="relative z-20 shrink-0 mt-2"
       :selected-line="selectedLine"
       :has-selected-line="hasSelectedLine"
       :progress-ms="progressMs"
@@ -10,12 +10,13 @@
       @update:words="handleWordsUpdate"
       @word-timing-edited="handleWordTimingEdited"
       @play-line="handlePlayLine"
+      @play-line-at-offset="handlePlayLineAtOffset"
       @select-next-line="selectLine"
     />
 
     <div
       ref="linesListElement"
-      class="flex-1 overflow-y-auto py-4 relative outline-none"
+      class="flex-1 overflow-y-auto py-4 relative z-0 outline-none"
       tabindex="0"
       @mousemove="handleMouseMove"
       @mouseleave="handleLinesMouseLeave"
@@ -163,6 +164,7 @@ const emit = defineEmits([
   'update:selected-line-index',
   'update:selected-line-indices',
   'play-line',
+  'play-line-at-offset',
   'sync-line',
   'rewind-line',
   'forward-line',
@@ -362,7 +364,11 @@ const emitLineAction = (eventName, index, selectBefore = true) => {
 }
 
 const handlePlayLine = index => {
-  emitLineAction('play-line', index)
+  emitLineAction('play-line', index, false)
+}
+
+const handlePlayLineAtOffset = payload => {
+  emit('play-line-at-offset', payload)
 }
 
 const handleSyncLine = index => {

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
@@ -38,6 +38,7 @@
             :index="index"
             :row-class="rowClass(index)"
             :is-line-controls-visible="isLineControlsVisible(index)"
+            :end-timestamp-diff-direction="getEndTimestampDiffDirection(index)"
             :is-editing="editingLineIndex === index"
             :editing-text="editingText"
             :timestamp-text="formatTimestampMs(line.start_ms)"
@@ -354,6 +355,17 @@ const selectLine = index => {
 
 const isLineControlsVisible = index =>
   hoveredLineIndex.value === index || props.selectedLineIndex === index || isLineRowSelected(index)
+
+const getEndTimestampDiffDirection = index => {
+  const lineEndMs = props.modelValue[index]?.end_ms
+  const nextLineStartMs = props.modelValue[index + 1]?.start_ms
+
+  if (!Number.isFinite(lineEndMs) || !Number.isFinite(nextLineStartMs) || lineEndMs === nextLineStartMs) {
+    return null
+  }
+
+  return lineEndMs < nextLineStartMs ? 'before' : 'after'
+}
 
 const emitLineAction = (eventName, index, selectBefore = true) => {
   if (selectBefore) {

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsLineRow.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsLineRow.vue
@@ -72,6 +72,17 @@
       @click="emit('select', index)"
       @dblclick="emit('start-edit', index)"
     >
+      <span
+        class="mr-2 shrink-0 inline-block w-2 h-2 rounded-full border"
+        :class="
+          hasWordSync
+            ? 'bg-emerald-500 border-emerald-500 dark:bg-emerald-400 dark:border-emerald-400'
+            : 'bg-neutral-300 border-neutral-400 dark:bg-neutral-600 dark:border-neutral-500'
+        "
+        :title="hasWordSync ? 'Word synced' : 'Word not synced'"
+        :aria-label="hasWordSync ? 'Word synced' : 'Word not synced'"
+      />
+
       <template v-if="hasWordSync">
         <span
           v-for="(word, wordIndex) in line.words"

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsLineRow.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsLineRow.vue
@@ -22,7 +22,7 @@
       <button
         v-show="isLineControlsVisible"
         class="button button-primary p-1 rounded-full text-sm h-6 w-6"
-        title="Sync line to current playback"
+        :title="syncLineTitle"
         @click.stop="emit('sync-line', index)"
       >
         <Equal />
@@ -33,7 +33,7 @@
       <button
         v-show="isLineControlsVisible && line.start_ms"
         class="button p-0.5 rounded-full text-xs h-5 w-5 bg-hoa-100 dark:bg-hoa-1500 text-hoa-800/70 dark:text-hoa-200/70 absolute -left-1.5 top-1/2 -translate-y-1/2 z-10"
-        title="Rewind line by 100ms"
+        :title="rewindLineTitle"
         @click.stop="emit('rewind-line', index)"
       >
         <Rewind />
@@ -47,7 +47,7 @@
       <button
         v-show="isLineControlsVisible && line.start_ms"
         class="button p-0.5 rounded-full text-xs h-5 w-5 bg-hoa-100 dark:bg-hoa-1500 text-hoa-800/70 dark:text-hoa-200/70 absolute -right-1.5 top-1/2 -translate-y-1/2 z-10"
-        title="Forward line by 100ms"
+        :title="forwardLineTitle"
         @click.stop="emit('forward-line', index)"
       >
         <Forward />
@@ -105,36 +105,39 @@
         <button
           v-show="isLineControlsVisible && line.end_ms"
           class="button p-0.5 rounded-full text-xs h-5 w-5 bg-neutral-200 dark:bg-neutral-700 text-neutral-600/70 dark:text-neutral-300/70 absolute -left-1.5 top-1/2 -translate-y-1/2 z-10"
-          title="Rewind end timestamp by 100ms"
+          :title="rewindEndTitle"
           @click.stop="emit('rewind-end', index)"
         >
           <Rewind />
         </button>
         <div
-          v-show="isLineControlsVisible"
-          class="px-3 py-0.5 text-xs font-mono rounded-full bg-neutral-200 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 min-w-[5.75rem] text-center"
-          :class="{ 'opacity-50': !line.end_ms }"
+          v-show="isLineControlsVisible || hasEndTimestampDiffDirection"
+          class="px-3 py-0.5 text-xs font-mono rounded-full min-w-[5.75rem] text-center"
+          :class="endTimestampPillClass"
+          :title="endTimestampPillTitle"
         >
           {{ endTimestampText }}
         </div>
         <button
           v-show="isLineControlsVisible && line.end_ms"
           class="button p-0.5 rounded-full text-xs h-5 w-5 bg-neutral-200 dark:bg-neutral-700 text-neutral-600/70 dark:text-neutral-300/70 absolute -right-1.5 top-1/2 -translate-y-1/2 z-10"
-          title="Forward end timestamp by 100ms"
+          :title="forwardEndTitle"
           @click.stop="emit('forward-end', index)"
         >
           <Forward />
         </button>
       </div>
 
-      <button
-        v-show="isLineControlsVisible"
-        class="button bg-neutral-200 text-neutral-600 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-300 hover:dark:bg-neutral-600 p-1 rounded-full text-sm h-6 w-6 mr-4"
-        title="Sync end timestamp to current playback"
-        @click.stop="emit('sync-end', index)"
-      >
-        <Equal />
-      </button>
+      <div class="h-6 w-6 mr-4 shrink-0">
+        <button
+          v-show="isLineControlsVisible"
+          class="button bg-neutral-200 text-neutral-600 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-300 hover:dark:bg-neutral-600 p-1 rounded-full text-sm h-6 w-6"
+          :title="syncEndTitle"
+          @click.stop="emit('sync-end', index)"
+        >
+          <Equal />
+        </button>
+      </div>
     </div>
 
     <div class="flex items-center gap-1 w-[3.5rem] justify-end">
@@ -158,6 +161,10 @@ import Rewind from '~icons/mdi/rewind'
 import Forward from '~icons/mdi/fast-forward'
 import Close from '~icons/mdi/close'
 import Trash from '~icons/mdi/trash-can'
+import {
+  syncedEditorShortcutBindings,
+  withShortcutTitle,
+} from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
 
 const props = defineProps({
   index: {
@@ -175,6 +182,10 @@ const props = defineProps({
   isLineControlsVisible: {
     type: Boolean,
     default: false,
+  },
+  endTimestampDiffDirection: {
+    type: String,
+    default: '',
   },
   isEditing: {
     type: Boolean,
@@ -254,6 +265,64 @@ const isLinePlaying = computed(() => {
 const editingTextProxy = computed({
   get: () => props.editingText,
   set: value => emit('update:editing-text', value),
+})
+
+const syncLineTitle = withShortcutTitle(
+  'Sync line to current playback',
+  syncedEditorShortcutBindings,
+  'syncLineToPlayback'
+)
+
+const rewindLineTitle = withShortcutTitle('Rewind line by 100ms', syncedEditorShortcutBindings, 'rewindLine')
+
+const forwardLineTitle = withShortcutTitle(
+  'Forward line by 100ms',
+  syncedEditorShortcutBindings,
+  'forwardLine'
+)
+
+const syncEndTitle = withShortcutTitle(
+  'Sync end timestamp to current playback',
+  syncedEditorShortcutBindings,
+  'syncLineEndToPlayback'
+)
+
+const rewindEndTitle = withShortcutTitle(
+  'Rewind end timestamp by 100ms',
+  syncedEditorShortcutBindings,
+  'rewindLineEnd'
+)
+
+const forwardEndTitle = withShortcutTitle(
+  'Forward end timestamp by 100ms',
+  syncedEditorShortcutBindings,
+  'forwardLineEnd'
+)
+
+const hasEndTimestampDiffDirection = computed(() => {
+  return props.endTimestampDiffDirection === 'before' || props.endTimestampDiffDirection === 'after'
+})
+
+const endTimestampPillClass = computed(() => ({
+  'bg-neutral-200 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300':
+    !hasEndTimestampDiffDirection.value,
+  'bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300':
+    props.endTimestampDiffDirection === 'before',
+  'bg-rose-100 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300':
+    props.endTimestampDiffDirection === 'after',
+  'opacity-50': !props.line?.end_ms,
+}))
+
+const endTimestampPillTitle = computed(() => {
+  if (props.endTimestampDiffDirection === 'before') {
+    return 'End timestamp is before next line start (gap)'
+  }
+
+  if (props.endTimestampDiffDirection === 'after') {
+    return 'End timestamp is after next line start (overlap)'
+  }
+
+  return 'End timestamp'
 })
 
 // Check if line has word-by-word synced data

--- a/src/components/library/edit-lyrics-v2/SyncedWordTimingLane.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedWordTimingLane.vue
@@ -44,7 +44,7 @@
         <div class="flex items-center gap-2">
           <button
             class="button button-normal text-xs px-2 py-1 rounded flex items-center gap-1"
-            title="Play line from beginning"
+            :title="playLineTitle"
             @click="handlePlayLine"
           >
             <Play class="w-3.5 h-3.5" />
@@ -52,7 +52,7 @@
           </button>
           <button
             class="button button-primary text-xs px-2 py-1 rounded flex items-center gap-1"
-            title="Sync word at current playback position (z)"
+            :title="syncWordTitle"
             @click="handleSyncWord"
           >
             <Equal class="w-3.5 h-3.5" />
@@ -92,8 +92,8 @@
           :key="index"
           :word="word"
           :word-index="index"
-          :next-word-text="displayedWords[index + 1]?.text || ''"
-          :next-word-start-ms="displayedWords[index + 1]?.start_ms ?? null"
+          :next-word-text="displayedWords[index]?.text || ''"
+          :next-word-start-ms="displayedWords[index]?.start_ms ?? null"
           :next-word-end-ms="
             index + 1 < displayedWords.length ? getWordEndMs(index + 1) : null
           "
@@ -163,6 +163,11 @@ import Close from '~icons/mdi/close'
 import SyncedWordTimingSegment from '@/components/library/edit-lyrics-v2/SyncedWordTimingSegment.vue'
 import { useEditLyricsV2WordBoundaryDrag } from '@/composables/edit-lyrics-v2/useEditLyricsV2WordBoundaryDrag.js'
 import { useEditLyricsV2WordTimingHotkeys } from '@/composables/edit-lyrics-v2/useEditLyricsV2WordTimingHotkeys.js'
+import {
+  syncedEditorShortcutBindings,
+  wordTimingShortcutBindings,
+  withShortcutTitle,
+} from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
 import { formatTimestampMs } from '@/utils/lyricsfile.js'
 import { ensureLineWords, distributeWordTimings, hasValidWords } from '@/utils/word-tokenizer.js'
 
@@ -197,6 +202,18 @@ const laneStartMs = ref(0)
 const laneEndMs = ref(0)
 const segmentedTokenTexts = ref(null)
 const segmentationRequestId = ref(0)
+
+const playLineTitle = withShortcutTitle(
+  'Play line from beginning',
+  syncedEditorShortcutBindings,
+  'replaySelectedLine'
+)
+
+const syncWordTitle = withShortcutTitle(
+  'Sync word at current playback position',
+  wordTimingShortcutBindings,
+  'syncSelectedSeparatorAndAdvance'
+)
 
 // Availability checks for word sync feature
 const hasLineContent = computed(() => {

--- a/src/components/library/edit-lyrics-v2/SyncedWordTimingLane.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedWordTimingLane.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative flex flex-col px-2 py-2 rounded-lg overflow-hidden h-[5rem] transition-[min-height] duration-200 ease-out"
+    class="relative z-20 flex flex-col px-2 py-2 rounded-lg overflow-visible h-[5rem] transition-[min-height] duration-200 ease-out"
     :class="hasSelectedLine ? 'bg-neutral-100 dark:bg-neutral-800' : 'bg-white dark:bg-neutral-950'"
   >
     <!-- Empty state - no line selected -->
@@ -92,12 +92,20 @@
           :key="index"
           :word="word"
           :word-index="index"
+          :next-word-text="displayedWords[index + 1]?.text || ''"
+          :next-word-start-ms="displayedWords[index + 1]?.start_ms ?? null"
+          :next-word-end-ms="
+            index + 1 < displayedWords.length ? getWordEndMs(index + 1) : null
+          "
           :start-ms="word.start_ms"
           :end-ms="getWordEndMs(index)"
           :line-start-ms="laneStartMs"
           :line-end-ms="laneEndMs"
           :timeline-width="timelineWidth"
           :progress-ms="progressMs"
+          :selected-boundary-index="selectedBoundaryIndex"
+          :selected-boundary-indices="selectedBoundaryIndices"
+          @split-at="handleSegmentSplitAt"
         />
 
         <button
@@ -108,7 +116,7 @@
           :style="{ left: `${timeToPercent(displayedWords[index].start_ms)}%` }"
           :title="`Adjust start of ${displayedWords[index].text}`"
           @pointerdown="handleBoundaryPointerDown(index, $event)"
-          @click="selectBoundary(index)"
+          @click="selectBoundary(index, $event)"
         >
           <span
             class="absolute left-1/2 top-0 bottom-0 w-0.5 -translate-x-1/2 transition-all duration-150 ease-linear bg-neutral-300/70 dark:bg-hoa-1000/70 group-hover:bg-neutral-600 dark:group-hover:bg-neutral-300 group-hover:w-[3px] group-hover:ring-1 group-hover:ring-neutral-500/25"
@@ -148,6 +156,7 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
 import Equal from '~icons/mdi/equal'
 import Play from '~icons/mdi/play'
 import Close from '~icons/mdi/close'
@@ -186,6 +195,8 @@ const timelineElement = ref(null)
 const timelineWidth = ref(0)
 const laneStartMs = ref(0)
 const laneEndMs = ref(0)
+const segmentedTokenTexts = ref(null)
+const segmentationRequestId = ref(0)
 
 // Availability checks for word sync feature
 const hasLineContent = computed(() => {
@@ -243,6 +254,23 @@ const syncLaneWindowToSelection = () => {
 const words = computed(() => {
   if (!isWordSyncAvailable.value) return []
 
+  if (!hasActualWords.value) {
+    const lineText = props.selectedLine?.text || ''
+    const charabiaTokens = segmentedTokenTexts.value
+
+    if (
+      Array.isArray(charabiaTokens) &&
+      charabiaTokens.length > 0 &&
+      charabiaTokens.join('') === lineText
+    ) {
+      return distributeWordTimings(
+        charabiaTokens.map(text => ({ text })),
+        lineStartMs.value,
+        actualLineEndMs.value
+      )
+    }
+  }
+
   const lineWithWords = ensureLineWords(props.selectedLine, props.allLines, props.selectedLineIndex)
 
   return lineWithWords.words || []
@@ -253,9 +281,14 @@ const {
   displayedWords,
   boundaryIndexes,
   selectedBoundaryIndex,
+  selectedBoundaryIndices,
   startBoundaryDrag,
   selectBoundary,
+  isBoundarySelected,
+  selectPreviousBoundary,
+  selectNextBoundary,
   syncSelectedBoundary,
+  deleteSelectedBoundaries,
   resetBoundarySelection,
   cancelBoundaryInteraction,
 } = useEditLyricsV2WordBoundaryDrag({
@@ -332,7 +365,7 @@ const getBoundaryLineClass = index => {
   const isActive =
     dragState.value?.rightWordIndex === index ||
     (!dragState.value && selectedBoundaryIndex.value === index)
-  const isSelected = !dragState.value && selectedBoundaryIndex.value === index
+  const isSelected = !dragState.value && isBoundarySelected(index)
 
   if (isSelected) {
     return 'bg-hoa-1000 dark:bg-neutral-300 w-[3px] ring-2 ring-neutral-300/35'
@@ -346,7 +379,20 @@ const getBoundaryLineClass = index => {
 }
 
 const handleSyncWord = () => {
-  syncSelectedBoundary(props.progressMs)
+  const selectedBoundaryBeforeSync = selectedBoundaryIndex.value
+  const synced = syncSelectedBoundary(props.progressMs)
+
+  if (
+    synced &&
+    selectedBoundaryBeforeSync === words.value.length - 1 &&
+    props.selectedLineIndex < props.allLines.length - 1
+  ) {
+    emit('select-next-line')
+  }
+}
+
+const handleSyncWordNoAdvance = () => {
+  syncSelectedBoundary(props.progressMs, { advance: false })
 }
 
 const handlePlayLine = () => {
@@ -354,14 +400,136 @@ const handlePlayLine = () => {
   emit('play-line', props.selectedLineIndex)
 }
 
+const splitTextByGrapheme = text => {
+  if (!text || typeof text !== 'string') {
+    return []
+  }
+
+  if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter('und', { granularity: 'grapheme' })
+    return Array.from(segmenter.segment(text), item => item.segment)
+  }
+
+  return Array.from(text)
+}
+
+const getWordEndMsFromList = (wordsList, index) => {
+  if (index >= wordsList.length - 1) {
+    return laneEndMs.value
+  }
+
+  const nextWordStart = wordsList[index + 1]?.start_ms
+  return Number.isFinite(nextWordStart) ? nextWordStart : laneEndMs.value
+}
+
+const handleDeleteSelectedBoundaries = () => {
+  if (!isWordSyncAvailable.value) return
+  deleteSelectedBoundaries()
+}
+
+const handleSegmentSplitAt = ({ wordIndex, splitIndex, splitRatio }) => {
+  if (!isWordSyncAvailable.value) {
+    return
+  }
+
+  if (!Number.isInteger(wordIndex) || wordIndex < 0 || wordIndex >= displayedWords.value.length) {
+    return
+  }
+
+  const currentWord = displayedWords.value[wordIndex]
+  const graphemes = splitTextByGrapheme(currentWord?.text || '')
+  if (graphemes.length <= 1) {
+    return
+  }
+
+  const fallbackSplitIndex = Math.max(1, Math.min(graphemes.length - 1, Math.floor(graphemes.length / 2)))
+  const normalizedSplitIndex = Number.isInteger(splitIndex)
+    ? Math.max(1, Math.min(graphemes.length - 1, splitIndex))
+    : fallbackSplitIndex
+
+  const leftText = graphemes.slice(0, normalizedSplitIndex).join('')
+  const rightText = graphemes.slice(normalizedSplitIndex).join('')
+
+  const wordStartMs = Number.isFinite(currentWord?.start_ms) ? currentWord.start_ms : laneStartMs.value
+  const wordEndMs = getWordEndMsFromList(displayedWords.value, wordIndex)
+  const normalizedSplitRatio = Number.isFinite(splitRatio)
+    ? Math.max(0, Math.min(1, splitRatio))
+    : normalizedSplitIndex / graphemes.length
+  const splitTimeMs = Math.max(
+    wordStartMs + 1,
+    Math.min(wordEndMs - 1, Math.round(wordStartMs + (wordEndMs - wordStartMs) * normalizedSplitRatio))
+  )
+
+  const updatedWords = [
+    ...displayedWords.value.slice(0, wordIndex),
+    { text: leftText, start_ms: wordStartMs },
+    { text: rightText, start_ms: splitTimeMs },
+    ...displayedWords.value.slice(wordIndex + 1),
+  ]
+
+  emit('update:words', {
+    lineIndex: props.selectedLineIndex,
+    words: updatedWords,
+    lineStartMs: laneStartMs.value,
+  })
+
+  selectBoundary(Math.min(updatedWords.length - 1, wordIndex + 1))
+}
+
+const loadDefaultSegmentation = async ({ force = false } = {}) => {
+  if (!isWordSyncAvailable.value) {
+    segmentedTokenTexts.value = null
+    return
+  }
+
+  if (!force && hasActualWords.value) {
+    segmentedTokenTexts.value = null
+    return
+  }
+
+  const lineText = props.selectedLine?.text || ''
+  if (!lineText) {
+    segmentedTokenTexts.value = []
+    return
+  }
+
+  const requestId = ++segmentationRequestId.value
+
+  try {
+    const tokens = await invoke('segment_words', { text: lineText })
+
+    if (requestId !== segmentationRequestId.value) {
+      return
+    }
+
+    if (!Array.isArray(tokens)) {
+      segmentedTokenTexts.value = null
+      return
+    }
+
+    segmentedTokenTexts.value = tokens
+      .filter(token => typeof token === 'string')
+      .filter(token => token.length > 0)
+  } catch (error) {
+    if (requestId !== segmentationRequestId.value) {
+      return
+    }
+
+    segmentedTokenTexts.value = null
+    console.error(error)
+  }
+}
+
 const { bindWordTimingHotkeys, unbindWordTimingHotkeys } = useEditLyricsV2WordTimingHotkeys({
   isWordSyncAvailable,
   selectedBoundaryIndex,
   words,
-  selectedLineIndex: computed(() => props.selectedLineIndex),
-  allLines: computed(() => props.allLines),
   syncSelectedBoundaryAtProgress: () => handleSyncWord(),
-  onSelectNextLine: nextLineIndex => emit('select-next-line', nextLineIndex),
+  syncSelectedBoundaryAtProgressNoAdvance: () => handleSyncWordNoAdvance(),
+  selectPreviousBoundary: () => selectPreviousBoundary(),
+  selectNextBoundary: () => selectNextBoundary(),
+  resetBoundarySelection: () => resetBoundarySelection(),
+  deleteSelectedBoundaries: () => handleDeleteSelectedBoundaries(),
 })
 
 watch(
@@ -375,6 +543,10 @@ watch(
     } else if (!props.hasSelectedLine) {
       syncLaneWindowToSelection()
     }
+
+    segmentedTokenTexts.value = null
+    void loadDefaultSegmentation()
+
     nextTick(() => {
       updateTimelineWidth()
     })
@@ -382,18 +554,21 @@ watch(
   { immediate: true }
 )
 
-const handleResetWords = () => {
+const handleResetWords = async () => {
   if (!isWordSyncAvailable.value) return
 
-  // Clear the words object entirely - this will make the timeline
-  // appear with balanced words but reduced opacity (auto-generated state)
+  // Clear the words object entirely - this removes persisted word timings.
   emit('update:words', {
     lineIndex: props.selectedLineIndex,
     words: undefined,
   })
 
-  // Reset selected boundary to first after reset
+  // Reset selected boundary after clearing.
   resetBoundarySelection()
+
+  // Wait for parent state to apply, then force segmentation so first reset is reliable.
+  await nextTick()
+  await loadDefaultSegmentation({ force: true })
 }
 
 const handleTimelineClick = event => {
@@ -418,13 +593,46 @@ watch(
 watch(isWordSyncAvailable, (available, wasAvailable) => {
   if (!available) {
     cancelBoundaryInteraction()
+    segmentedTokenTexts.value = null
     return
   }
 
   if (!wasAvailable) {
     syncLaneWindowToSelection()
+    segmentedTokenTexts.value = null
+    void loadDefaultSegmentation()
   }
 })
+
+watch(hasActualWords, (hasWords, hadWords) => {
+  if (hadWords && !hasWords && isWordSyncAvailable.value) {
+    segmentedTokenTexts.value = null
+    void loadDefaultSegmentation()
+  }
+})
+
+watch(
+  () => props.selectedLine?.text,
+  () => {
+    segmentedTokenTexts.value = null
+    if (isWordSyncAvailable.value) {
+      void loadDefaultSegmentation()
+    }
+  }
+)
+
+watch(
+  [lineStartMs, actualLineEndMs],
+  () => {
+    if (!props.hasSelectedLine || !props.selectedLine) {
+      return
+    }
+
+    laneStartMs.value = lineStartMs.value
+    laneEndMs.value = actualLineEndMs.value
+  },
+  { immediate: true }
+)
 
 watch(
   () => props.allLines,

--- a/src/components/library/edit-lyrics-v2/SyncedWordTimingSegment.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedWordTimingSegment.vue
@@ -35,7 +35,7 @@
     <div
       v-if="showNextWordHint"
       class="absolute left-1/2 top-full z-40 mt-1 -translate-x-1/2 px-2 py-0.5 rounded-md border border-hoa-1100/40 bg-hoa-1100 text-xs font-medium leading-4 text-white shadow-sm whitespace-nowrap pointer-events-none"
-      :style="{ left: `${nextSegmentCenterOffsetPx}px` }"
+      :style="{ left: 0 }"
       :title="`Next word: ${nextWordHintText}`"
     >
       {{ nextWordHintText }}
@@ -155,12 +155,6 @@ const currentSegmentWidthPx = computed(() => {
   return (currentDuration / lineDuration) * props.timelineWidth
 })
 
-const nextSegmentCenterOffsetPx = computed(() => {
-  // Hint element is positioned relative to current segment.
-  // Move to center of the next segment: current width + half next width.
-  return currentSegmentWidthPx.value + nextSegmentWidthPx.value / 2
-})
-
 const doesNextWordOverflow = computed(() => {
   if (!nextWordHintText.value || nextSegmentWidthPx.value <= 0) {
     return false
@@ -179,7 +173,7 @@ const isSelectedDividerForNextSegment = computed(() => {
     return false
   }
 
-  const nextBoundaryIndex = props.wordIndex + 1
+  const nextBoundaryIndex = props.wordIndex
 
   if (props.selectedBoundaryIndex === nextBoundaryIndex) {
     return true
@@ -193,7 +187,6 @@ const isSelectedDividerForNextSegment = computed(() => {
 const showNextWordHint = computed(() => {
   return (
     isSelectedDividerForNextSegment.value &&
-    doesNextWordOverflow.value &&
     nextWordHintText.value.length > 0
   )
 })

--- a/src/components/library/edit-lyrics-v2/SyncedWordTimingSegment.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedWordTimingSegment.vue
@@ -1,17 +1,53 @@
 <template>
   <div
-    class="word-segment absolute flex items-center justify-center px-1 py-1 text-sm select-none h-full"
+    ref="segmentElement"
+    class="word-segment absolute flex items-center justify-center px-1 py-1 text-sm select-none h-full overflow-visible"
     :class="segmentClass"
     :style="segmentStyle"
     :title="`${word.text} (${formatTimestampMs(startMs)} - ${formatTimestampMs(endMs)})`"
+    @mouseenter="handleSegmentHover"
+    @mousemove="handleSegmentHover"
+    @mouseleave="handleSegmentLeave"
+    @dblclick.stop="handleSegmentDoubleClick"
   >
-    <span class="truncate">{{ word.text }}</span>
+    <div
+      ref="previewContainerElement"
+      class="relative flex items-center justify-center w-full h-full min-w-0 overflow-hidden"
+    >
+      <span
+        ref="textElement"
+        class="relative z-10 block max-w-full overflow-hidden whitespace-nowrap text-clip"
+      >
+        {{ word.text }}
+      </span>
+
+      <div
+        v-if="hoverPreview"
+        class="absolute inset-y-0 pointer-events-none z-20"
+        :style="{ left: `${hoverPreview.splitX}px` }"
+      >
+        <div
+          class="absolute top-0 bottom-0 w-[2px] -translate-x-1/2 bg-neutral-500/80 dark:bg-neutral-200/90 ring-1 ring-neutral-500/20"
+        />
+      </div>
+    </div>
+
+    <div
+      v-if="showNextWordHint"
+      class="absolute left-1/2 top-full z-40 mt-1 -translate-x-1/2 px-2 py-0.5 rounded-md border border-hoa-1100/40 bg-hoa-1100 text-xs font-medium leading-4 text-white shadow-sm whitespace-nowrap pointer-events-none"
+      :style="{ left: `${nextSegmentCenterOffsetPx}px` }"
+      :title="`Next word: ${nextWordHintText}`"
+    >
+      {{ nextWordHintText }}
+    </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { formatTimestampMs } from '@/utils/lyricsfile.js'
+
+const emit = defineEmits(['split-at'])
 
 const props = defineProps({
   word: {
@@ -46,7 +82,259 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
+  nextWordText: {
+    type: String,
+    default: '',
+  },
+  nextWordStartMs: {
+    type: Number,
+    default: null,
+  },
+  nextWordEndMs: {
+    type: Number,
+    default: null,
+  },
+  selectedBoundaryIndex: {
+    type: Number,
+    default: -1,
+  },
+  selectedBoundaryIndices: {
+    type: Array,
+    default: () => [],
+  },
 })
+
+const segmentElement = ref(null)
+const previewContainerElement = ref(null)
+const textElement = ref(null)
+const hoverPreview = ref(null)
+
+const nextWordHintText = computed(() => (props.nextWordText || '').trim())
+
+const nextSegmentWidthPx = computed(() => {
+  if (!Number.isFinite(props.timelineWidth) || props.timelineWidth <= 0) {
+    return 0
+  }
+
+  if (
+    !Number.isFinite(props.lineStartMs) ||
+    !Number.isFinite(props.lineEndMs) ||
+    props.lineEndMs <= props.lineStartMs
+  ) {
+    return 0
+  }
+
+  if (!Number.isFinite(props.nextWordStartMs) || !Number.isFinite(props.nextWordEndMs)) {
+    return 0
+  }
+
+  const lineDuration = props.lineEndMs - props.lineStartMs
+  const nextDuration = Math.max(0, props.nextWordEndMs - props.nextWordStartMs)
+  return (nextDuration / lineDuration) * props.timelineWidth
+})
+
+const currentSegmentWidthPx = computed(() => {
+  if (!Number.isFinite(props.timelineWidth) || props.timelineWidth <= 0) {
+    return 0
+  }
+
+  if (
+    !Number.isFinite(props.lineStartMs) ||
+    !Number.isFinite(props.lineEndMs) ||
+    props.lineEndMs <= props.lineStartMs
+  ) {
+    return 0
+  }
+
+  if (!Number.isFinite(props.startMs) || !Number.isFinite(props.endMs)) {
+    return 0
+  }
+
+  const lineDuration = props.lineEndMs - props.lineStartMs
+  const currentDuration = Math.max(0, props.endMs - props.startMs)
+  return (currentDuration / lineDuration) * props.timelineWidth
+})
+
+const nextSegmentCenterOffsetPx = computed(() => {
+  // Hint element is positioned relative to current segment.
+  // Move to center of the next segment: current width + half next width.
+  return currentSegmentWidthPx.value + nextSegmentWidthPx.value / 2
+})
+
+const doesNextWordOverflow = computed(() => {
+  if (!nextWordHintText.value || nextSegmentWidthPx.value <= 0) {
+    return false
+  }
+
+  const font = textElement.value ? getComputedStyle(textElement.value).font : '14px sans-serif'
+  const textWidth = measureTextWidth(nextWordHintText.value, font)
+
+  // Segment uses horizontal padding (px-1), so reserve a small visual margin.
+  const availableWidth = Math.max(0, nextSegmentWidthPx.value - 8)
+  return textWidth > availableWidth + 1
+})
+
+const isSelectedDividerForNextSegment = computed(() => {
+  if (!Number.isFinite(props.nextWordStartMs)) {
+    return false
+  }
+
+  const nextBoundaryIndex = props.wordIndex + 1
+
+  if (props.selectedBoundaryIndex === nextBoundaryIndex) {
+    return true
+  }
+
+  return Array.isArray(props.selectedBoundaryIndices)
+    ? props.selectedBoundaryIndices.includes(nextBoundaryIndex)
+    : false
+})
+
+const showNextWordHint = computed(() => {
+  return (
+    isSelectedDividerForNextSegment.value &&
+    doesNextWordOverflow.value &&
+    nextWordHintText.value.length > 0
+  )
+})
+
+const splitTextByGrapheme = text => {
+  if (!text || typeof text !== 'string') {
+    return []
+  }
+
+  if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter('und', { granularity: 'grapheme' })
+    return Array.from(segmenter.segment(text), item => item.segment)
+  }
+
+  return Array.from(text)
+}
+
+const measureTextWidth = (text, font) => {
+  if (typeof document === 'undefined') {
+    return 0
+  }
+
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+
+  if (!context) {
+    return 0
+  }
+
+  context.font = font
+  return context.measureText(text).width
+}
+
+const getSplitPreview = clientX => {
+  if (!segmentElement.value || !previewContainerElement.value || !textElement.value) {
+    return null
+  }
+
+  const text = props.word.text || ''
+  const graphemes = splitTextByGrapheme(text)
+  if (graphemes.length <= 1) {
+    return null
+  }
+
+  const segmentRect = segmentElement.value.getBoundingClientRect()
+  const previewContainerRect = previewContainerElement.value.getBoundingClientRect()
+  const textRect = textElement.value.getBoundingClientRect()
+  if (segmentRect.width <= 0 || previewContainerRect.width <= 0 || textRect.width <= 0) {
+    return null
+  }
+
+  const textNode = textElement.value.firstChild
+  if (textNode && textNode.nodeType === Node.TEXT_NODE) {
+    const pointerClientX = Math.max(textRect.left, Math.min(textRect.right, clientX))
+    const range = document.createRange()
+    const boundaries = []
+
+    for (let index = 1; index < graphemes.length; index++) {
+      const offset = graphemes.slice(0, index).join('').length
+
+      range.setStart(textNode, 0)
+      range.setEnd(textNode, offset)
+
+      const boundaryRect = range.getBoundingClientRect()
+      const boundaryClientX = boundaryRect.right
+
+      if (!Number.isFinite(boundaryClientX)) {
+        continue
+      }
+
+      boundaries.push({
+        splitIndex: index,
+        measuredWidth: Math.max(0, boundaryClientX - textRect.left),
+        splitX: boundaryClientX - previewContainerRect.left,
+      })
+    }
+
+    if (boundaries.length > 0) {
+      let nearestBoundary = boundaries[0]
+      let nearestDistance = Math.abs(pointerClientX - (previewContainerRect.left + nearestBoundary.splitX))
+
+      for (const boundary of boundaries.slice(1)) {
+        const distance = Math.abs(pointerClientX - (previewContainerRect.left + boundary.splitX))
+        if (distance < nearestDistance) {
+          nearestBoundary = boundary
+          nearestDistance = distance
+        }
+      }
+
+      const splitRatio = Math.max(0, Math.min(1, nearestBoundary.measuredWidth / textRect.width))
+
+      return {
+        splitIndex: nearestBoundary.splitIndex,
+        splitRatio,
+        splitX: nearestBoundary.splitX,
+      }
+    }
+  }
+
+  const font = getComputedStyle(textElement.value).font
+  const graphemeWidths = graphemes.map(grapheme => measureTextWidth(grapheme, font))
+  const totalMeasuredWidth = graphemeWidths.reduce((sum, width) => sum + width, 0)
+
+  if (totalMeasuredWidth <= 0) {
+    return null
+  }
+
+  const cumulativeBoundaries = []
+  let runningWidth = 0
+  for (let index = 0; index < graphemeWidths.length - 1; index++) {
+    runningWidth += graphemeWidths[index]
+    cumulativeBoundaries.push({
+      splitIndex: index + 1,
+      measuredWidth: runningWidth,
+    })
+  }
+
+  const pointerOffset = Math.max(0, Math.min(textRect.width, clientX - textRect.left))
+  const scaledOffset = (pointerOffset / textRect.width) * totalMeasuredWidth
+
+  let nearestBoundary = cumulativeBoundaries[0]
+  let nearestDistance = Math.abs(scaledOffset - nearestBoundary.measuredWidth)
+
+  for (const boundary of cumulativeBoundaries.slice(1)) {
+    const distance = Math.abs(scaledOffset - boundary.measuredWidth)
+    if (distance < nearestDistance) {
+      nearestBoundary = boundary
+      nearestDistance = distance
+    }
+  }
+
+  const splitX =
+    (nearestBoundary.measuredWidth / totalMeasuredWidth) * textRect.width +
+    (textRect.left - previewContainerRect.left)
+
+  return {
+    splitIndex: nearestBoundary.splitIndex,
+    splitRatio: nearestBoundary.measuredWidth / totalMeasuredWidth,
+    splitX,
+  }
+}
 
 const isPlaying = computed(() => {
   // The word is playing when: startMs <= currentTime < endMs
@@ -87,15 +375,35 @@ const segmentStyle = computed(() => {
   const leftPercent = ((props.startMs - props.lineStartMs) / duration) * 100
   const wordDuration = Math.max(0, props.endMs - props.startMs)
   const widthPercent = (wordDuration / duration) * 100
-  const minWidth = Math.max(24, (props.word.text?.length || 1) * 6)
 
   return {
     left: `${leftPercent}%`,
     width: `${widthPercent}%`,
-    minWidth: `${minWidth}px`,
     transition: 'none',
   }
 })
+
+const handleSegmentDoubleClick = event => {
+  const splitPreview = getSplitPreview(event.clientX)
+  if (!splitPreview) {
+    return
+  }
+
+  emit('split-at', {
+    wordIndex: props.wordIndex,
+    splitIndex: splitPreview.splitIndex,
+    splitRatio: splitPreview.splitRatio,
+  })
+}
+
+const handleSegmentHover = event => {
+  hoverPreview.value = getSplitPreview(event.clientX)
+}
+
+const handleSegmentLeave = () => {
+  hoverPreview.value = null
+}
+
 </script>
 
 <style scoped>

--- a/src/composables/edit-lyrics-v2/keyboardShortcuts.js
+++ b/src/composables/edit-lyrics-v2/keyboardShortcuts.js
@@ -1,43 +1,6 @@
-export const shortcutCategories = [
-  {
-    id: 'global',
-    label: 'Global',
-    shortcuts: [
-      { keys: ['Ctrl', 'S'], description: 'Save lyrics' },
-    ],
-  },
-  {
-    id: 'plain',
-    label: 'Plain Editor',
-    shortcuts: [
-      { keys: ['Ctrl', '+'], description: 'Zoom in' },
-      { keys: ['Ctrl', '-'], description: 'Zoom out' },
-      { keys: ['Ctrl', '0'], description: 'Reset zoom' },
-      { keys: ['Ctrl', 'Scroll'], description: 'Zoom in/out' },
-    ],
-  },
-  {
-    id: 'synced',
-    label: 'Synced Editor',
-    shortcuts: [
-      { keys: ['↑'], description: 'Select previous line' },
-      { keys: ['↓'], description: 'Select next line' },
-      { keys: ['Space'], description: 'Sync line to current playback' },
-      { keys: ['Enter'], description: 'Sync line & move to next' },
-      { keys: ['←'], description: 'Rewind 100 ms & play' },
-      { keys: ['→'], description: 'Forward 100 ms & play' },
-      { keys: ['P'], description: 'Replay selected line' },
-    ],
-  },
-  {
-    id: 'wordTiming',
-    label: 'Word Timing',
-    shortcuts: [
-      { keys: ['Z'], description: 'Sync word at current playback' },
-      { keys: ['X'], description: 'Sync word & advance to next line' },
-    ],
-  },
-]
+import { shortcutCategories } from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
+
+export { shortcutCategories }
 
 export function getShortcutsForTab(activeTab) {
   const result = [...shortcutCategories.find(c => c.id === 'global').shortcuts]

--- a/src/composables/edit-lyrics-v2/keyboardShortcuts.js
+++ b/src/composables/edit-lyrics-v2/keyboardShortcuts.js
@@ -1,15 +1,18 @@
-import { shortcutCategories } from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
+import { getShortcutCategories } from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
 
-export { shortcutCategories }
+export const shortcutCategories = getShortcutCategories()
+
+export const getKeyboardShortcutCategories = () => getShortcutCategories()
 
 export function getShortcutsForTab(activeTab) {
-  const result = [...shortcutCategories.find(c => c.id === 'global').shortcuts]
+  const categories = getShortcutCategories()
+  const result = [...categories.find(c => c.id === 'global').shortcuts]
 
   if (activeTab === 'plain') {
-    result.push(...shortcutCategories.find(c => c.id === 'plain').shortcuts)
+    result.push(...categories.find(c => c.id === 'plain').shortcuts)
   } else if (activeTab === 'synced') {
-    result.push(...shortcutCategories.find(c => c.id === 'synced').shortcuts)
-    result.push(...shortcutCategories.find(c => c.id === 'wordTiming').shortcuts)
+    result.push(...categories.find(c => c.id === 'synced').shortcuts)
+    result.push(...categories.find(c => c.id === 'wordTiming').shortcuts)
   }
 
   return result

--- a/src/composables/edit-lyrics-v2/shortcutRegistry.js
+++ b/src/composables/edit-lyrics-v2/shortcutRegistry.js
@@ -1,0 +1,181 @@
+const normalizeKey = key => (typeof key === 'string' && key.length === 1 ? key.toLowerCase() : key)
+
+const isCtrlPressed = event => event.ctrlKey || event.metaKey
+
+const hasExactModifiers = (event, { ctrl = false, alt = false, shift = false }) => {
+  if (isCtrlPressed(event) !== ctrl) {
+    return false
+  }
+
+  if (event.altKey !== alt) {
+    return false
+  }
+
+  if (event.shiftKey !== shift) {
+    return false
+  }
+
+  return true
+}
+
+const matchesShortcut = (event, { key, code, ctrl = false, alt = false, shift = false }) => {
+  if (!hasExactModifiers(event, { ctrl, alt, shift })) {
+    return false
+  }
+
+  if (code && event.code === code) {
+    return true
+  }
+
+  return normalizeKey(event.key) === normalizeKey(key)
+}
+
+export const globalShortcutBindings = [
+  {
+    id: 'saveLyrics',
+    keys: ['Ctrl', 'S'],
+    description: 'Save lyrics',
+    matches: event => matchesShortcut(event, { key: 's', ctrl: true }),
+  },
+  {
+    id: 'openShortcutModal',
+    keys: ['Ctrl', '/'],
+    description: 'Open keyboard shortcuts',
+    matches: event =>
+      hasExactModifiers(event, { ctrl: true }) &&
+      (normalizeKey(event.key) === '/' || normalizeKey(event.key) === '?' || event.code === 'Slash'),
+  },
+]
+
+export const plainEditorShortcutBindings = [
+  {
+    id: 'zoomIn',
+    keys: ['Ctrl', '+'],
+    description: 'Zoom in',
+    matches: event =>
+      hasExactModifiers(event, { ctrl: true }) &&
+      (normalizeKey(event.key) === '+' || normalizeKey(event.key) === '='),
+  },
+  {
+    id: 'zoomOut',
+    keys: ['Ctrl', '-'],
+    description: 'Zoom out',
+    matches: event =>
+      hasExactModifiers(event, { ctrl: true }) &&
+      (normalizeKey(event.key) === '-' || normalizeKey(event.key) === '_'),
+  },
+  {
+    id: 'zoomReset',
+    keys: ['Ctrl', '0'],
+    description: 'Reset zoom',
+    matches: event => matchesShortcut(event, { key: '0', ctrl: true }),
+  },
+]
+
+export const plainEditorDisplayOnlyShortcuts = [
+  { keys: ['Ctrl', 'Scroll'], description: 'Zoom in/out' },
+]
+
+export const syncedEditorShortcutBindings = [
+  {
+    id: 'selectPreviousLine',
+    keys: ['↑'],
+    description: 'Select previous line',
+    matches: event => matchesShortcut(event, { key: 'ArrowUp' }),
+  },
+  {
+    id: 'selectNextLine',
+    keys: ['↓'],
+    description: 'Select next line',
+    matches: event => matchesShortcut(event, { key: 'ArrowDown' }),
+  },
+  {
+    id: 'syncLineToPlayback',
+    keys: ['Space'],
+    description: 'Sync line to current playback',
+    matches: event => matchesShortcut(event, { key: ' ' }),
+  },
+  {
+    id: 'syncLineEndToPlayback',
+    keys: ['Ctrl', 'Space'],
+    description: 'Sync selected line end to current playback',
+    matches: event => matchesShortcut(event, { key: ' ', ctrl: true }),
+  },
+  {
+    id: 'syncLineAndAdvance',
+    keys: ['Enter'],
+    description: 'Sync line, sync previous line end & move to next',
+    matches: event => matchesShortcut(event, { key: 'Enter' }),
+  },
+  {
+    id: 'syncLineAndAdvanceNoPreviousEndSync',
+    keys: ['Ctrl', 'Enter'],
+    description: 'Sync line & move to next (skip previous line end sync)',
+    matches: event => matchesShortcut(event, { key: 'Enter', ctrl: true }),
+  },
+  {
+    id: 'rewindLine',
+    keys: ['←'],
+    description: 'Rewind 100 ms & play',
+    matches: event => matchesShortcut(event, { key: 'ArrowLeft' }),
+  },
+  {
+    id: 'forwardLine',
+    keys: ['→'],
+    description: 'Forward 100 ms & play',
+    matches: event => matchesShortcut(event, { key: 'ArrowRight' }),
+  },
+  {
+    id: 'replaySelectedLine',
+    keys: ['P'],
+    description: 'Replay selected line',
+    matches: event => matchesShortcut(event, { key: 'p', ctrl: false, shift: false }) && !event.altKey,
+  },
+  {
+    id: 'deleteSelectedLine',
+    keys: ['Backspace'],
+    description: 'Delete selected line',
+    matches: event => matchesShortcut(event, { key: 'Backspace' }),
+  },
+]
+
+export const wordTimingShortcutBindings = [
+  {
+    id: 'syncSelectedSeparatorAndAdvance',
+    keys: ['Z'],
+    description: 'Sync selected separator & move to next',
+    matches: event => matchesShortcut(event, { key: 'z' }),
+  },
+  {
+    id: 'resetSeparatorCursor',
+    keys: ['X'],
+    description: 'Reset separator cursor to second divider',
+    matches: event => matchesShortcut(event, { key: 'x' }),
+  },
+]
+
+export const shortcutCategories = [
+  {
+    id: 'global',
+    label: 'Global',
+    shortcuts: globalShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+  },
+  {
+    id: 'plain',
+    label: 'Plain Editor',
+    shortcuts: [
+      ...plainEditorShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+      ...plainEditorDisplayOnlyShortcuts,
+    ],
+  },
+  {
+    id: 'synced',
+    label: 'Synced Editor',
+    shortcuts: syncedEditorShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+  },
+  {
+    id: 'wordTiming',
+    label: 'Word Timing',
+    shortcuts: wordTimingShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+  },
+]

--- a/src/composables/edit-lyrics-v2/shortcutRegistry.js
+++ b/src/composables/edit-lyrics-v2/shortcutRegistry.js
@@ -1,3 +1,5 @@
+const SHORTCUT_OVERRIDES_STORAGE_KEY = 'lrcget.edit-lyrics-v2.shortcut-overrides'
+
 const normalizeKey = key => (typeof key === 'string' && key.length === 1 ? key.toLowerCase() : key)
 
 const isCtrlPressed = event => event.ctrlKey || event.metaKey
@@ -18,200 +20,418 @@ const hasExactModifiers = (event, { ctrl = false, alt = false, shift = false }) 
   return true
 }
 
-const matchesShortcut = (event, { key, code, ctrl = false, alt = false, shift = false }) => {
+const isShortcutKeys = keys => {
+  return Array.isArray(keys) && keys.length > 0 && keys.every(key => typeof key === 'string' && key.trim())
+}
+
+const normalizeShortcutKeys = keys => {
+  if (!isShortcutKeys(keys)) {
+    return null
+  }
+
+  return keys.map(key => key.trim())
+}
+
+const loadShortcutOverrides = () => {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SHORTCUT_OVERRIDES_STORAGE_KEY)
+    if (!raw) {
+      return {}
+    }
+
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    const normalized = {}
+    for (const [shortcutId, keys] of Object.entries(parsed)) {
+      const normalizedKeys = normalizeShortcutKeys(keys)
+      if (normalizedKeys) {
+        normalized[shortcutId] = normalizedKeys
+      }
+    }
+
+    return normalized
+  } catch {
+    return {}
+  }
+}
+
+const persistShortcutOverrides = overrides => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(SHORTCUT_OVERRIDES_STORAGE_KEY, JSON.stringify(overrides))
+  } catch {
+    // Ignore storage failures and keep in-memory overrides.
+  }
+}
+
+let shortcutOverrides = loadShortcutOverrides()
+
+export const getShortcutOverrides = () => ({ ...shortcutOverrides })
+
+export const resolveShortcutKeys = (shortcutId, fallbackKeys = []) => {
+  const overrideKeys = shortcutOverrides[shortcutId]
+  const normalizedOverrideKeys = normalizeShortcutKeys(overrideKeys)
+  if (normalizedOverrideKeys) {
+    return normalizedOverrideKeys
+  }
+
+  const normalizedFallbackKeys = normalizeShortcutKeys(fallbackKeys)
+  return normalizedFallbackKeys || []
+}
+
+export const setShortcutOverride = (shortcutId, keys) => {
+  if (typeof shortcutId !== 'string' || !shortcutId.trim()) {
+    return false
+  }
+
+  const normalizedKeys = normalizeShortcutKeys(keys)
+  if (!normalizedKeys) {
+    return false
+  }
+
+  shortcutOverrides = {
+    ...shortcutOverrides,
+    [shortcutId]: normalizedKeys,
+  }
+
+  persistShortcutOverrides(shortcutOverrides)
+  return true
+}
+
+export const resetShortcutOverride = shortcutId => {
+  if (typeof shortcutId !== 'string' || !shortcutId.trim()) {
+    return false
+  }
+
+  if (!(shortcutId in shortcutOverrides)) {
+    return true
+  }
+
+  const { [shortcutId]: _removed, ...nextOverrides } = shortcutOverrides
+  shortcutOverrides = nextOverrides
+  persistShortcutOverrides(shortcutOverrides)
+  return true
+}
+
+export const resetAllShortcutOverrides = () => {
+  shortcutOverrides = {}
+  persistShortcutOverrides(shortcutOverrides)
+}
+
+const shortcutTokenToEventKey = {
+  '↑': 'ArrowUp',
+  '↓': 'ArrowDown',
+  '←': 'ArrowLeft',
+  '→': 'ArrowRight',
+  Space: ' ',
+  Enter: 'Enter',
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+}
+
+const matchesMainShortcutKey = (event, keyToken) => {
+  if (keyToken === '/') {
+    return normalizeKey(event.key) === '/' || normalizeKey(event.key) === '?' || event.code === 'Slash'
+  }
+
+  if (keyToken === '+') {
+    return normalizeKey(event.key) === '+' || normalizeKey(event.key) === '=' || event.code === 'Equal'
+  }
+
+  if (keyToken === '-') {
+    return normalizeKey(event.key) === '-' || normalizeKey(event.key) === '_' || event.code === 'Minus'
+  }
+
+  const eventKey = shortcutTokenToEventKey[keyToken] || keyToken
+  return normalizeKey(event.key) === normalizeKey(eventKey)
+}
+
+const matchesShortcutKeys = (event, shortcutKeys) => {
+  const normalizedKeys = normalizeShortcutKeys(shortcutKeys)
+  if (!normalizedKeys) {
+    return false
+  }
+
+  const ctrl = normalizedKeys.includes('Ctrl')
+  const alt = normalizedKeys.includes('Alt')
+  const shift = normalizedKeys.includes('Shift')
+  const mainKey = normalizedKeys.find(key => key !== 'Ctrl' && key !== 'Alt' && key !== 'Shift')
+
+  if (!mainKey) {
+    return false
+  }
+
   if (!hasExactModifiers(event, { ctrl, alt, shift })) {
     return false
   }
 
-  if (code && event.code === code) {
-    return true
-  }
-
-  return normalizeKey(event.key) === normalizeKey(key)
+  return matchesMainShortcutKey(event, mainKey)
 }
 
+export const shortcutKeysFromKeyboardEvent = event => {
+  const keys = []
+
+  if (isCtrlPressed(event)) {
+    keys.push('Ctrl')
+  }
+
+  if (event.altKey) {
+    keys.push('Alt')
+  }
+
+  if (event.shiftKey) {
+    keys.push('Shift')
+  }
+
+  const baseKey =
+    event.key === ' '
+      ? 'Space'
+      : event.key === 'ArrowUp'
+        ? '↑'
+        : event.key === 'ArrowDown'
+          ? '↓'
+          : event.key === 'ArrowLeft'
+            ? '←'
+            : event.key === 'ArrowRight'
+              ? '→'
+              : event.key
+
+  const ignoredBaseKeys = ['Control', 'Meta', 'Alt', 'Shift']
+  if (!ignoredBaseKeys.includes(baseKey)) {
+    if (baseKey.length === 1) {
+      keys.push(baseKey.toUpperCase())
+    } else {
+      keys.push(baseKey)
+    }
+  }
+
+  const hasNonModifierKey = keys.some(key => key !== 'Ctrl' && key !== 'Alt' && key !== 'Shift')
+  return hasNonModifierKey ? keys : []
+}
+
+const createShortcutBinding = ({ id, defaultKeys, description }) => ({
+  id,
+  description,
+  get defaultKeys() {
+    return normalizeShortcutKeys(defaultKeys) || []
+  },
+  get keys() {
+    return resolveShortcutKeys(id, defaultKeys)
+  },
+  matches: event => matchesShortcutKeys(event, resolveShortcutKeys(id, defaultKeys)),
+})
+
 export const globalShortcutBindings = [
-  {
+  createShortcutBinding({
     id: 'saveLyrics',
-    keys: ['Ctrl', 'S'],
+    defaultKeys: ['Ctrl', 'S'],
     description: 'Save lyrics',
-    matches: event => matchesShortcut(event, { key: 's', ctrl: true }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'openShortcutModal',
-    keys: ['Ctrl', '/'],
+    defaultKeys: ['Ctrl', '/'],
     description: 'Open keyboard shortcuts',
-    matches: event =>
-      hasExactModifiers(event, { ctrl: true }) &&
-      (normalizeKey(event.key) === '/' || normalizeKey(event.key) === '?' || event.code === 'Slash'),
-  },
+  }),
 ]
 
 export const plainEditorShortcutBindings = [
-  {
+  createShortcutBinding({
     id: 'zoomIn',
-    keys: ['Ctrl', '+'],
+    defaultKeys: ['Ctrl', '+'],
     description: 'Zoom in',
-    matches: event =>
-      hasExactModifiers(event, { ctrl: true }) &&
-      (normalizeKey(event.key) === '+' || normalizeKey(event.key) === '='),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'zoomOut',
-    keys: ['Ctrl', '-'],
+    defaultKeys: ['Ctrl', '-'],
     description: 'Zoom out',
-    matches: event =>
-      hasExactModifiers(event, { ctrl: true }) &&
-      (normalizeKey(event.key) === '-' || normalizeKey(event.key) === '_'),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'zoomReset',
-    keys: ['Ctrl', '0'],
+    defaultKeys: ['Ctrl', '0'],
     description: 'Reset zoom',
-    matches: event => matchesShortcut(event, { key: '0', ctrl: true }),
-  },
+  }),
 ]
 
-export const plainEditorDisplayOnlyShortcuts = [
-  { keys: ['Ctrl', 'Scroll'], description: 'Zoom in/out' },
-]
+export const plainEditorDisplayOnlyShortcuts = [{ keys: ['Ctrl', 'Scroll'], description: 'Zoom in/out' }]
 
 export const syncedEditorShortcutBindings = [
-  {
+  createShortcutBinding({
     id: 'selectPreviousLine',
-    keys: ['↑'],
+    defaultKeys: ['↑'],
     description: 'Select previous line',
-    matches: event => matchesShortcut(event, { key: 'ArrowUp' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'selectNextLine',
-    keys: ['↓'],
+    defaultKeys: ['↓'],
     description: 'Select next line',
-    matches: event => matchesShortcut(event, { key: 'ArrowDown' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncLineToPlayback',
-    keys: ['Space'],
+    defaultKeys: ['Space'],
     description: 'Sync line to current playback',
-    matches: event => matchesShortcut(event, { key: ' ' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncLineEndToPlayback',
-    keys: ['Shift', 'Space'],
+    defaultKeys: ['Shift', 'Space'],
     description: 'Sync selected line end to current playback',
-    matches: event => matchesShortcut(event, { key: ' ', shift: true }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncLineEndAndAdvance',
-    keys: ['N'],
+    defaultKeys: ['N'],
     description: 'Sync selected line end & move to next',
-    matches: event => matchesShortcut(event, { key: 'n' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncLineAndAdvance',
-    keys: ['Enter'],
+    defaultKeys: ['Enter'],
     description: 'Sync line, sync previous line end & move to next',
-    matches: event => matchesShortcut(event, { key: 'Enter' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncLineAndAdvanceNoPreviousEndSync',
-    keys: ['Shift', 'Enter'],
-    description: 'Sync line & move to next (skip previous line end sync)',
-    matches: event => matchesShortcut(event, { key: 'Enter', shift: true }),
-  },
-  {
+    defaultKeys: ['Shift', 'Enter'],
+    description: 'Sync line & move to next (skip line end sync)',
+  }),
+  createShortcutBinding({
     id: 'rewindLine',
-    keys: ['←'],
+    defaultKeys: ['←'],
     description: 'Rewind 100 ms & play',
-    matches: event => matchesShortcut(event, { key: 'ArrowLeft' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'forwardLine',
-    keys: ['→'],
+    defaultKeys: ['→'],
     description: 'Forward 100 ms & play',
-    matches: event => matchesShortcut(event, { key: 'ArrowRight' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'replaySelectedLine',
-    keys: ['P'],
+    defaultKeys: ['P'],
     description: 'Replay selected line',
-    matches: event => matchesShortcut(event, { key: 'p', ctrl: false, shift: false }) && !event.altKey,
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'replayPreviousLine',
-    keys: ['Shift', 'P'],
+    defaultKeys: ['Shift', 'P'],
     description: 'Replay previous line',
-    matches: event => matchesShortcut(event, { key: 'p', ctrl: false, shift: true }) && !event.altKey,
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'deleteSelectedLine',
-    keys: ['Backspace'],
+    defaultKeys: ['Backspace'],
     description: 'Delete selected line',
-    matches: event => matchesShortcut(event, { key: 'Backspace' }),
-  },
+  }),
 ]
 
 export const wordTimingShortcutBindings = [
-  {
+  createShortcutBinding({
     id: 'selectPreviousSeparator',
-    keys: ['A'],
+    defaultKeys: ['A'],
     description: 'Select previous separator',
-    matches: event => matchesShortcut(event, { key: 'a' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'selectNextSeparator',
-    keys: ['D'],
+    defaultKeys: ['D'],
     description: 'Select next separator',
-    matches: event => matchesShortcut(event, { key: 'd' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncSelectedSeparatorNoAdvance',
-    keys: ['S'],
+    defaultKeys: ['S'],
     description: 'Sync selected separator (stay selected)',
-    matches: event => matchesShortcut(event, { key: 's' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'syncSelectedSeparatorAndAdvance',
-    keys: ['Z'],
+    defaultKeys: ['Z'],
     description: 'Sync selected separator & move to next',
-    matches: event => matchesShortcut(event, { key: 'z' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'resetSeparatorCursor',
-    keys: ['X'],
+    defaultKeys: ['X'],
     description: 'Reset separator cursor to second divider',
-    matches: event => matchesShortcut(event, { key: 'x' }),
-  },
-  {
+  }),
+  createShortcutBinding({
     id: 'deleteSelectedSeparators',
-    keys: ['Delete'],
+    defaultKeys: ['Delete'],
     description: 'Delete selected separators to merge adjacent words',
-    matches: event => matchesShortcut(event, { key: 'Delete' }),
-  },
+  }),
 ]
 
-export const shortcutCategories = [
+export const getShortcutCategories = () => [
   {
     id: 'global',
     label: 'Global',
-    shortcuts: globalShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+    shortcuts: globalShortcutBindings.map(({ id, keys, defaultKeys, description }) => ({
+      id,
+      keys,
+      defaultKeys,
+      description,
+    })),
   },
   {
     id: 'plain',
     label: 'Plain Editor',
     shortcuts: [
-      ...plainEditorShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+      ...plainEditorShortcutBindings.map(({ id, keys, defaultKeys, description }) => ({
+        id,
+        keys,
+        defaultKeys,
+        description,
+      })),
       ...plainEditorDisplayOnlyShortcuts,
     ],
   },
   {
     id: 'synced',
     label: 'Synced Editor',
-    shortcuts: syncedEditorShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+    shortcuts: syncedEditorShortcutBindings.map(({ id, keys, defaultKeys, description }) => ({
+      id,
+      keys,
+      defaultKeys,
+      description,
+    })),
   },
   {
     id: 'wordTiming',
     label: 'Word Timing',
-    shortcuts: wordTimingShortcutBindings.map(({ keys, description }) => ({ keys, description })),
+    shortcuts: wordTimingShortcutBindings.map(({ id, keys, defaultKeys, description }) => ({
+      id,
+      keys,
+      defaultKeys,
+      description,
+    })),
   },
 ]
+
+export const shortcutCategories = getShortcutCategories()
+
+export const formatShortcutKeys = keys => {
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return ''
+  }
+
+  return keys.join('+')
+}
+
+export const findShortcutById = (bindings, shortcutId) => {
+  if (!Array.isArray(bindings) || typeof shortcutId !== 'string') {
+    return null
+  }
+
+  return bindings.find(binding => binding.id === shortcutId) || null
+}
+
+export const withShortcutTitle = (title, bindings, shortcutId) => {
+  const baseTitle = typeof title === 'string' ? title : ''
+  const binding = findShortcutById(bindings, shortcutId)
+  const shortcutLabel = formatShortcutKeys(binding?.keys)
+
+  if (!shortcutLabel) {
+    return baseTitle
+  }
+
+  return `${baseTitle} (${shortcutLabel})`
+}

--- a/src/composables/edit-lyrics-v2/shortcutRegistry.js
+++ b/src/composables/edit-lyrics-v2/shortcutRegistry.js
@@ -97,9 +97,15 @@ export const syncedEditorShortcutBindings = [
   },
   {
     id: 'syncLineEndToPlayback',
-    keys: ['Ctrl', 'Space'],
+    keys: ['Shift', 'Space'],
     description: 'Sync selected line end to current playback',
-    matches: event => matchesShortcut(event, { key: ' ', ctrl: true }),
+    matches: event => matchesShortcut(event, { key: ' ', shift: true }),
+  },
+  {
+    id: 'syncLineEndAndAdvance',
+    keys: ['N'],
+    description: 'Sync selected line end & move to next',
+    matches: event => matchesShortcut(event, { key: 'n' }),
   },
   {
     id: 'syncLineAndAdvance',
@@ -109,9 +115,9 @@ export const syncedEditorShortcutBindings = [
   },
   {
     id: 'syncLineAndAdvanceNoPreviousEndSync',
-    keys: ['Ctrl', 'Enter'],
+    keys: ['Shift', 'Enter'],
     description: 'Sync line & move to next (skip previous line end sync)',
-    matches: event => matchesShortcut(event, { key: 'Enter', ctrl: true }),
+    matches: event => matchesShortcut(event, { key: 'Enter', shift: true }),
   },
   {
     id: 'rewindLine',
@@ -132,6 +138,12 @@ export const syncedEditorShortcutBindings = [
     matches: event => matchesShortcut(event, { key: 'p', ctrl: false, shift: false }) && !event.altKey,
   },
   {
+    id: 'replayPreviousLine',
+    keys: ['Shift', 'P'],
+    description: 'Replay previous line',
+    matches: event => matchesShortcut(event, { key: 'p', ctrl: false, shift: true }) && !event.altKey,
+  },
+  {
     id: 'deleteSelectedLine',
     keys: ['Backspace'],
     description: 'Delete selected line',
@@ -140,6 +152,24 @@ export const syncedEditorShortcutBindings = [
 ]
 
 export const wordTimingShortcutBindings = [
+  {
+    id: 'selectPreviousSeparator',
+    keys: ['A'],
+    description: 'Select previous separator',
+    matches: event => matchesShortcut(event, { key: 'a' }),
+  },
+  {
+    id: 'selectNextSeparator',
+    keys: ['D'],
+    description: 'Select next separator',
+    matches: event => matchesShortcut(event, { key: 'd' }),
+  },
+  {
+    id: 'syncSelectedSeparatorNoAdvance',
+    keys: ['S'],
+    description: 'Sync selected separator (stay selected)',
+    matches: event => matchesShortcut(event, { key: 's' }),
+  },
   {
     id: 'syncSelectedSeparatorAndAdvance',
     keys: ['Z'],
@@ -151,6 +181,12 @@ export const wordTimingShortcutBindings = [
     keys: ['X'],
     description: 'Reset separator cursor to second divider',
     matches: event => matchesShortcut(event, { key: 'x' }),
+  },
+  {
+    id: 'deleteSelectedSeparators',
+    keys: ['Delete'],
+    description: 'Delete selected separators to merge adjacent words',
+    matches: event => matchesShortcut(event, { key: 'Delete' }),
   },
 ]
 

--- a/src/composables/edit-lyrics-v2/shortcutRegistry.js
+++ b/src/composables/edit-lyrics-v2/shortcutRegistry.js
@@ -311,6 +311,16 @@ export const syncedEditorShortcutBindings = [
     description: 'Forward 100 ms & play',
   }),
   createShortcutBinding({
+    id: 'rewindLineEnd',
+    defaultKeys: ['Shift', '←'],
+    description: 'Rewind line end by 100 ms',
+  }),
+  createShortcutBinding({
+    id: 'forwardLineEnd',
+    defaultKeys: ['Shift', '→'],
+    description: 'Forward line end by 100 ms',
+  }),
+  createShortcutBinding({
     id: 'replaySelectedLine',
     defaultKeys: ['P'],
     description: 'Replay selected line',

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2Document.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2Document.js
@@ -236,12 +236,26 @@ export function useEditLyricsV2Document({ audioSource, lyricsfile, trackId, prog
     }))
   }
 
+  const shiftWordBoundariesByOffset = (words, offsetMs) => {
+    if (!Array.isArray(words) || words.length === 0 || !Number.isFinite(offsetMs) || offsetMs === 0) {
+      return words
+    }
+
+    return words.map(word => ({
+      ...word,
+      start_ms: Math.max(0, Math.round((word?.start_ms ?? 0) + offsetMs)),
+    }))
+  }
+
   const syncLineToCurrentProgress = lineIndex => {
     if (!Number.isInteger(lineIndex) || lineIndex < 0 || lineIndex >= syncedLines.value.length) {
       return
     }
 
+    const currentLine = syncedLines.value[lineIndex]
+    const previousStartMs = Number.isFinite(currentLine?.start_ms) ? currentLine.start_ms : null
     const newStartMs = Math.max(0, Math.round(progress.value * 1000))
+    const lineStartOffsetMs = previousStartMs == null ? 0 : newStartMs - previousStartMs
 
     // Update the current line's start_ms and optionally set previous line's end_ms
     const prevLineIndex = lineIndex - 1
@@ -253,6 +267,7 @@ export function useEditLyricsV2Document({ audioSource, lyricsfile, trackId, prog
         return {
           ...line,
           start_ms: newStartMs,
+          words: shiftWordBoundariesByOffset(line.words, lineStartOffsetMs),
         }
       }
       if (index === prevLineIndex && shouldSetPrevEndMs) {

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2Hotkeys.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2Hotkeys.js
@@ -1,16 +1,48 @@
-export function useEditLyricsV2Hotkeys({ activeTab, saveLyrics, changeFontSizeBy, resetFontSize }) {
-  const isCtrlPressed = event => event.ctrlKey || event.metaKey
+import {
+  globalShortcutBindings,
+  plainEditorShortcutBindings,
+} from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
+
+export function useEditLyricsV2Hotkeys({
+  activeTab,
+  saveLyrics,
+  changeFontSizeBy,
+  resetFontSize,
+  openShortcutsModal,
+}) {
+  const runGlobalAction = actionId => {
+    switch (actionId) {
+      case 'openShortcutModal':
+        openShortcutsModal()
+        return
+      case 'saveLyrics':
+        saveLyrics()
+        return
+    }
+  }
+
+  const runPlainAction = actionId => {
+    switch (actionId) {
+      case 'zoomIn':
+        changeFontSizeBy(1)
+        return
+      case 'zoomOut':
+        changeFontSizeBy(-1)
+        return
+      case 'zoomReset':
+        resetFontSize()
+        return
+    }
+  }
 
   const handleKeyboardShortcuts = event => {
-    if (!isCtrlPressed(event)) {
-      return
-    }
+    for (const binding of globalShortcutBindings) {
+      if (!binding.matches(event)) {
+        continue
+      }
 
-    const key = event.key.toLowerCase()
-
-    if (key === 's') {
       event.preventDefault()
-      saveLyrics()
+      runGlobalAction(binding.id)
       return
     }
 
@@ -18,21 +50,14 @@ export function useEditLyricsV2Hotkeys({ activeTab, saveLyrics, changeFontSizeBy
       return
     }
 
-    if (key === '+' || key === '=') {
-      event.preventDefault()
-      changeFontSizeBy(1)
-      return
-    }
+    for (const binding of plainEditorShortcutBindings) {
+      if (!binding.matches(event)) {
+        continue
+      }
 
-    if (key === '-' || key === '_') {
       event.preventDefault()
-      changeFontSizeBy(-1)
+      runPlainAction(binding.id)
       return
-    }
-
-    if (key === '0') {
-      event.preventDefault()
-      resetFontSize()
     }
   }
 

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2Playback.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2Playback.js
@@ -18,13 +18,14 @@ export function useEditLyricsV2Playback({
       : playingTrack.value.file_path === audioSource.value.file_path
   }
 
-  const playLine = async lineIndex => {
+  const playLineAtOffset = async (lineIndex, offsetMs = 0) => {
     if (!audioSource.value) {
       return
     }
 
     const lineStartMs = syncedLines.value[lineIndex]?.start_ms
-    const seekTo = Number.isFinite(lineStartMs) ? lineStartMs / 1000 : progress.value
+    const baseStartMs = Number.isFinite(lineStartMs) ? lineStartMs : progress.value * 1000
+    const seekTo = Math.max(0, baseStartMs + offsetMs) / 1000
 
     if (!isPlayingCorrectTrack()) {
       await playTrack(audioSource.value)
@@ -33,6 +34,10 @@ export function useEditLyricsV2Playback({
     }
 
     seek(seekTo)
+  }
+
+  const playLine = async lineIndex => {
+    return playLineAtOffset(lineIndex, 0)
   }
 
   const resumeOrPlay = () => {
@@ -48,6 +53,7 @@ export function useEditLyricsV2Playback({
 
   return {
     playLine,
+    playLineAtOffset,
     resumeOrPlay,
   }
 }

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2SyncedHotkeys.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2SyncedHotkeys.js
@@ -7,6 +7,7 @@ export function useEditLyricsV2SyncedHotkeys({
   selectedSyncedLineIndex,
   selectedSyncedLineIndices,
   syncedLines,
+  progressMs,
   selectSyncedLine,
   clearSyncedLineSelection,
   syncLineToCurrentProgress,
@@ -14,6 +15,7 @@ export function useEditLyricsV2SyncedHotkeys({
   deleteSyncedLine,
   rewindLineBy100,
   forwardLineBy100,
+  playLineAtOffset,
   playLine,
 }) {
   const isKeyboardTargetEditable = event => {
@@ -49,6 +51,22 @@ export function useEditLyricsV2SyncedHotkeys({
       case 'syncLineEndToPlayback':
         syncEndToCurrentProgress(selectedSyncedLineIndex.value)
         return
+      case 'syncLineEndAndAdvance': {
+        const currentLineIndex = selectedSyncedLineIndex.value
+        const currentLineEndMs = syncedLines.value[currentLineIndex]?.end_ms
+        const currentPlaybackMs = Number(progressMs?.value)
+        const isAfterCurrentEnd =
+          Number.isFinite(currentLineEndMs) &&
+          Number.isFinite(currentPlaybackMs) &&
+          currentPlaybackMs > currentLineEndMs
+
+        if (!isAfterCurrentEnd) {
+          syncEndToCurrentProgress(currentLineIndex)
+        }
+
+        selectSyncedLine(Math.min(syncedLines.value.length - 1, currentLineIndex + 1))
+        return
+      }
       case 'syncLineAndAdvance': {
         const currentLineIndex = selectedSyncedLineIndex.value
         syncLineToCurrentProgress(currentLineIndex)
@@ -73,6 +91,17 @@ export function useEditLyricsV2SyncedHotkeys({
       case 'forwardLine':
         forwardLineBy100(selectedSyncedLineIndex.value)
         return
+      case 'replayPreviousLine': {
+        const previousLineIndex = selectedSyncedLineIndex.value - 1
+        if (previousLineIndex < 0) {
+          const currentLineStartMs = syncedLines.value[selectedSyncedLineIndex.value]?.start_ms
+          const fallbackOffsetMs = Number.isFinite(currentLineStartMs) ? -currentLineStartMs : 0
+          playLineAtOffset(selectedSyncedLineIndex.value, fallbackOffsetMs)
+          return
+        }
+        playLineAtOffset(previousLineIndex, 0)
+        return
+      }
       case 'replaySelectedLine':
         playLine(selectedSyncedLineIndex.value)
         return

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2SyncedHotkeys.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2SyncedHotkeys.js
@@ -1,3 +1,5 @@
+import { syncedEditorShortcutBindings } from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
+
 export function useEditLyricsV2SyncedHotkeys({
   activeTab,
   isSyncedLineEditing,
@@ -8,6 +10,8 @@ export function useEditLyricsV2SyncedHotkeys({
   selectSyncedLine,
   clearSyncedLineSelection,
   syncLineToCurrentProgress,
+  syncEndToCurrentProgress,
+  deleteSyncedLine,
   rewindLineBy100,
   forwardLineBy100,
   playLine,
@@ -31,6 +35,53 @@ export function useEditLyricsV2SyncedHotkeys({
     }
   }
 
+  const runSyncedAction = actionId => {
+    switch (actionId) {
+      case 'selectPreviousLine':
+        selectSyncedLine(Math.max(0, selectedSyncedLineIndex.value - 1))
+        return
+      case 'selectNextLine':
+        selectSyncedLine(Math.min(syncedLines.value.length - 1, selectedSyncedLineIndex.value + 1))
+        return
+      case 'syncLineToPlayback':
+        syncLineToCurrentProgress(selectedSyncedLineIndex.value)
+        return
+      case 'syncLineEndToPlayback':
+        syncEndToCurrentProgress(selectedSyncedLineIndex.value)
+        return
+      case 'syncLineAndAdvance': {
+        const currentLineIndex = selectedSyncedLineIndex.value
+        syncLineToCurrentProgress(currentLineIndex)
+
+        const previousLineIndex = currentLineIndex - 1
+        if (previousLineIndex >= 0) {
+          syncEndToCurrentProgress(previousLineIndex)
+        }
+
+        selectSyncedLine(Math.min(syncedLines.value.length - 1, selectedSyncedLineIndex.value + 1))
+        return
+      }
+      case 'syncLineAndAdvanceNoPreviousEndSync': {
+        const currentLineIndex = selectedSyncedLineIndex.value
+        syncLineToCurrentProgress(currentLineIndex)
+        selectSyncedLine(Math.min(syncedLines.value.length - 1, selectedSyncedLineIndex.value + 1))
+        return
+      }
+      case 'rewindLine':
+        rewindLineBy100(selectedSyncedLineIndex.value)
+        return
+      case 'forwardLine':
+        forwardLineBy100(selectedSyncedLineIndex.value)
+        return
+      case 'replaySelectedLine':
+        playLine(selectedSyncedLineIndex.value)
+        return
+      case 'deleteSelectedLine':
+        deleteSyncedLine(selectedSyncedLineIndex.value)
+        return
+    }
+  }
+
   const handleSyncedEditorKeyboardShortcuts = event => {
     if (
       activeTab.value !== 'synced' ||
@@ -41,53 +92,15 @@ export function useEditLyricsV2SyncedHotkeys({
       return
     }
 
-    if (event.key === 'ArrowUp') {
-      event.preventDefault()
-      clearSelectionIfNeeded()
-      selectSyncedLine(Math.max(0, selectedSyncedLineIndex.value - 1))
-      return
-    }
+    for (const binding of syncedEditorShortcutBindings) {
+      if (!binding.matches(event)) {
+        continue
+      }
 
-    if (event.key === 'ArrowDown') {
       event.preventDefault()
       clearSelectionIfNeeded()
-      selectSyncedLine(Math.min(syncedLines.value.length - 1, selectedSyncedLineIndex.value + 1))
+      runSyncedAction(binding.id)
       return
-    }
-
-    if (event.key === ' ') {
-      event.preventDefault()
-      clearSelectionIfNeeded()
-      syncLineToCurrentProgress(selectedSyncedLineIndex.value)
-      return
-    }
-
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      clearSelectionIfNeeded()
-      syncLineToCurrentProgress(selectedSyncedLineIndex.value)
-      selectSyncedLine(Math.min(syncedLines.value.length - 1, selectedSyncedLineIndex.value + 1))
-      return
-    }
-
-    if (event.key === 'ArrowLeft') {
-      event.preventDefault()
-      clearSelectionIfNeeded()
-      rewindLineBy100(selectedSyncedLineIndex.value)
-      return
-    }
-
-    if (event.key === 'ArrowRight') {
-      event.preventDefault()
-      clearSelectionIfNeeded()
-      forwardLineBy100(selectedSyncedLineIndex.value)
-      return
-    }
-
-    if (event.key.toLowerCase() === 'p') {
-      event.preventDefault()
-      clearSelectionIfNeeded()
-      playLine(selectedSyncedLineIndex.value)
     }
   }
 

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2SyncedHotkeys.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2SyncedHotkeys.js
@@ -15,6 +15,8 @@ export function useEditLyricsV2SyncedHotkeys({
   deleteSyncedLine,
   rewindLineBy100,
   forwardLineBy100,
+  rewindEndBy100,
+  forwardEndBy100,
   playLineAtOffset,
   playLine,
 }) {
@@ -90,6 +92,12 @@ export function useEditLyricsV2SyncedHotkeys({
         return
       case 'forwardLine':
         forwardLineBy100(selectedSyncedLineIndex.value)
+        return
+      case 'rewindLineEnd':
+        rewindEndBy100(selectedSyncedLineIndex.value)
+        return
+      case 'forwardLineEnd':
+        forwardEndBy100(selectedSyncedLineIndex.value)
         return
       case 'replayPreviousLine': {
         const previousLineIndex = selectedSyncedLineIndex.value - 1

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2WordBoundaryDrag.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2WordBoundaryDrag.js
@@ -14,6 +14,7 @@ export function useEditLyricsV2WordBoundaryDrag({
 }) {
   const dragState = ref(null)
   const selectedBoundaryIndex = ref(0)
+  const selectedBoundaryIndices = ref([0])
   const isDraggingBoundary = ref(false)
   const dragStartPos = ref(null)
 
@@ -62,7 +63,7 @@ export function useEditLyricsV2WordBoundaryDrag({
     const nextStartMs = currentWords[rightWordIndex + 1]?.start_ms
 
     if (rightWordIndex === 0) {
-      const minStartMs = timelineStartMs.value
+      const minStartMs = Number.isFinite(timelineStartMs.value) ? timelineStartMs.value : 0
       const maxStartMs = Number.isFinite(nextStartMs) ? nextStartMs - 1 : timelineEndMs.value - 1
 
       return {
@@ -124,6 +125,40 @@ export function useEditLyricsV2WordBoundaryDrag({
     }
 
     return true
+  }
+
+  const normalizeSelection = indices => {
+    const maxIndex = Math.max(0, words.value.length - 1)
+    const uniqueSorted = [...new Set(indices.filter(Number.isInteger))]
+      .filter(index => index >= 0 && index <= maxIndex)
+      .sort((a, b) => a - b)
+
+    if (uniqueSorted.length === 0 && words.value.length > 0) {
+      return [Math.min(Math.max(selectedBoundaryIndex.value, 0), maxIndex)]
+    }
+
+    return uniqueSorted
+  }
+
+  const applySelection = (indices, preferredIndex) => {
+    const normalized = normalizeSelection(indices)
+    selectedBoundaryIndices.value = normalized
+
+    if (normalized.length === 0) {
+      selectedBoundaryIndex.value = 0
+      return
+    }
+
+    if (Number.isInteger(preferredIndex) && normalized.includes(preferredIndex)) {
+      selectedBoundaryIndex.value = preferredIndex
+      return
+    }
+
+    if (normalized.includes(selectedBoundaryIndex.value)) {
+      return
+    }
+
+    selectedBoundaryIndex.value = normalized[0]
   }
 
   const handlePointerMove = event => {
@@ -212,7 +247,7 @@ export function useEditLyricsV2WordBoundaryDrag({
     document.addEventListener('pointercancel', handlePotentialDragEnd)
   }
 
-  const selectBoundary = index => {
+  const selectBoundary = (index, event) => {
     if (!isWordSyncAvailable.value || index < 0 || index >= words.value.length) {
       return
     }
@@ -221,42 +256,158 @@ export function useEditLyricsV2WordBoundaryDrag({
       return
     }
 
-    selectedBoundaryIndex.value = index
+    const currentSelection = selectedBoundaryIndices.value
+
+    if (event?.shiftKey && currentSelection.length > 0) {
+      const anchor = selectedBoundaryIndex.value
+      const min = Math.min(anchor, index)
+      const max = Math.max(anchor, index)
+      const range = Array.from({ length: max - min + 1 }, (_, offset) => min + offset)
+      applySelection(range, index)
+      return
+    }
+
+    if (event?.ctrlKey || event?.metaKey) {
+      const nextSelection = currentSelection.includes(index)
+        ? currentSelection.filter(value => value !== index)
+        : [...currentSelection, index]
+      applySelection(nextSelection, index)
+      return
+    }
+
+    applySelection([index], index)
   }
 
-  const syncSelectedBoundary = progressMs => {
+  const isBoundarySelected = index => selectedBoundaryIndices.value.includes(index)
+
+  const selectPreviousBoundary = () => {
+    if (!isWordSyncAvailable.value || words.value.length === 0) {
+      return false
+    }
+
+    const nextIndex = Math.max(0, selectedBoundaryIndex.value - 1)
+    applySelection([nextIndex], nextIndex)
+    return true
+  }
+
+  const selectNextBoundary = () => {
+    if (!isWordSyncAvailable.value || words.value.length === 0) {
+      return false
+    }
+
+    const nextIndex = Math.min(words.value.length - 1, selectedBoundaryIndex.value + 1)
+    applySelection([nextIndex], nextIndex)
+    return true
+  }
+
+  const syncSelectedBoundary = (progressMs, options = {}) => {
     if (!isWordSyncAvailable.value) {
       return false
     }
+
+    const advance = options.advance !== false
 
     const rightWordIndex = selectedBoundaryIndex.value
     if (rightWordIndex < 0 || rightWordIndex >= words.value.length) {
       return false
     }
 
-    const { minStartMs, maxStartMs } = getBoundaryConstraint(rightWordIndex)
-    const newStartMs = Math.max(minStartMs, Math.min(maxStartMs, progressMs))
-    const oldStartMs = words.value[rightWordIndex].start_ms
+    const currentWords = words.value
+    const timelineMinStartMs = Number.isFinite(timelineStartMs.value) ? timelineStartMs.value : 0
+    const timelineMaxStartMs = Math.max(timelineMinStartMs, timelineEndMs.value - 1)
+    const boundaryCount = currentWords.length
 
-    if (newStartMs !== oldStartMs) {
-      commitBoundary({
-        rightWordIndex,
-        startMs: newStartMs,
-        initialStartMs: oldStartMs,
-        shouldReplay: false,
+    const absoluteMinForSelected = timelineMinStartMs + rightWordIndex
+    const absoluteMaxForSelected = timelineMaxStartMs - (boundaryCount - 1 - rightWordIndex)
+    const nextStartMs = Math.max(
+      absoluteMinForSelected,
+      Math.min(absoluteMaxForSelected, progressMs)
+    )
+
+    const nextStartValues = currentWords.map(word => word.start_ms)
+    nextStartValues[rightWordIndex] = nextStartMs
+
+    for (let index = rightWordIndex - 1; index >= 0; index--) {
+      const minStartMs = timelineMinStartMs + index
+      const maxStartMs = nextStartValues[index + 1] - 1
+      nextStartValues[index] = Math.max(minStartMs, Math.min(nextStartValues[index], maxStartMs))
+    }
+
+    for (let index = rightWordIndex + 1; index < boundaryCount; index++) {
+      const minStartMs = nextStartValues[index - 1] + 1
+      const maxStartMs = timelineMaxStartMs - (boundaryCount - 1 - index)
+      nextStartValues[index] = Math.min(maxStartMs, Math.max(nextStartValues[index], minStartMs))
+    }
+
+    const hasChanges = nextStartValues.some((startMs, index) => startMs !== currentWords[index].start_ms)
+
+    if (hasChanges) {
+      const updatedWords = currentWords.map((word, index) => ({
+        ...word,
+        start_ms: nextStartValues[index],
+      }))
+
+      onUpdateWords({
+        lineIndex: selectedLineIndex.value,
+        words: updatedWords,
+        lineStartMs: updatedWords[0].start_ms,
       })
     }
 
-    const nextIndex = rightWordIndex + 1
-    if (nextIndex < words.value.length) {
-      selectedBoundaryIndex.value = nextIndex
+    if (advance) {
+      const nextIndex = rightWordIndex + 1
+      if (nextIndex < words.value.length) {
+        applySelection([nextIndex], nextIndex)
+      }
     }
 
     return true
   }
 
+  const deleteSelectedBoundaries = () => {
+    if (!isWordSyncAvailable.value || words.value.length <= 1) {
+      return false
+    }
+
+    // Boundary 0 defines the line start and cannot be deleted.
+    const deletableBoundaries = selectedBoundaryIndices.value
+      .filter(index => index > 0 && index < words.value.length)
+      .sort((a, b) => a - b)
+
+    if (deletableBoundaries.length === 0) {
+      return false
+    }
+
+    const deletedSet = new Set(deletableBoundaries)
+    const mergedWords = []
+
+    for (let index = 0; index < words.value.length; index++) {
+      const word = words.value[index]
+
+      if (index > 0 && deletedSet.has(index) && mergedWords.length > 0) {
+        mergedWords[mergedWords.length - 1] = {
+          ...mergedWords[mergedWords.length - 1],
+          text: `${mergedWords[mergedWords.length - 1].text || ''}${word.text || ''}`,
+        }
+        continue
+      }
+
+      mergedWords.push({ ...word })
+    }
+
+    onUpdateWords({
+      lineIndex: selectedLineIndex.value,
+      words: mergedWords,
+    })
+
+    const nextPrimary = Math.max(0, Math.min(mergedWords.length - 1, deletableBoundaries[0] - 1))
+    applySelection([nextPrimary], nextPrimary)
+    return true
+  }
+
   const resetBoundarySelection = () => {
-    selectedBoundaryIndex.value = 0
+    const defaultBoundaryIndex = Math.min(1, Math.max(0, words.value.length - 1))
+    applySelection([defaultBoundaryIndex], defaultBoundaryIndex)
   }
 
   const cancelBoundaryInteraction = () => {
@@ -271,10 +422,15 @@ export function useEditLyricsV2WordBoundaryDrag({
     displayedWords,
     boundaryIndexes,
     selectedBoundaryIndex,
+    selectedBoundaryIndices,
     isDraggingBoundary,
     startBoundaryDrag,
     selectBoundary,
+    isBoundarySelected,
+    selectPreviousBoundary,
+    selectNextBoundary,
     syncSelectedBoundary,
+    deleteSelectedBoundaries,
     stopBoundaryDrag,
     resetBoundarySelection,
     cancelBoundaryInteraction,

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2WordTimingHotkeys.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2WordTimingHotkeys.js
@@ -1,11 +1,15 @@
+import { wordTimingShortcutBindings } from '@/composables/edit-lyrics-v2/shortcutRegistry.js'
+
 export function useEditLyricsV2WordTimingHotkeys({
   isWordSyncAvailable,
   selectedBoundaryIndex,
   words,
-  selectedLineIndex,
-  allLines,
   syncSelectedBoundaryAtProgress,
-  onSelectNextLine,
+  syncSelectedBoundaryAtProgressNoAdvance,
+  selectPreviousBoundary,
+  selectNextBoundary,
+  resetBoundarySelection,
+  deleteSelectedBoundaries,
 }) {
   const handleWordTimingKeyDown = event => {
     if (!isWordSyncAvailable.value) {
@@ -17,25 +21,31 @@ export function useEditLyricsV2WordTimingHotkeys({
       return
     }
 
-    switch (event.key.toLowerCase()) {
-      case 'z':
-        event.preventDefault()
-        syncSelectedBoundaryAtProgress()
-        break
-      case 'x': {
-        event.preventDefault()
-        const isAtLastBoundary = selectedBoundaryIndex.value >= words.value.length - 1
-        syncSelectedBoundaryAtProgress()
+    for (const binding of wordTimingShortcutBindings) {
+      if (!binding.matches(event)) {
+        continue
+      }
 
-        if (!isAtLastBoundary) {
-          break
-        }
-
-        const nextLineIndex = selectedLineIndex.value + 1
-        if (nextLineIndex < allLines.value.length) {
-          onSelectNextLine(nextLineIndex)
-        }
-        break
+      event.preventDefault()
+      switch (binding.id) {
+        case 'selectPreviousSeparator':
+          selectPreviousBoundary()
+          return
+        case 'selectNextSeparator':
+          selectNextBoundary()
+          return
+        case 'syncSelectedSeparatorNoAdvance':
+          syncSelectedBoundaryAtProgressNoAdvance()
+          return
+        case 'syncSelectedSeparatorAndAdvance':
+          syncSelectedBoundaryAtProgress()
+          return
+        case 'resetSeparatorCursor':
+          resetBoundarySelection()
+          return
+        case 'deleteSelectedSeparators':
+          deleteSelectedBoundaries()
+          return
       }
     }
   }

--- a/src/composables/player.js
+++ b/src/composables/player.js
@@ -7,12 +7,14 @@ const status = ref('stopped')
 const duration = ref(null)
 const progress = ref(null)
 const volume = ref(1.0)
+const playbackSpeed = ref(1.0)
 
 listen('player-state', async event => {
   duration.value = event.payload.duration
   progress.value = event.payload.progress
   status.value = event.payload.status
   volume.value = event.payload.volume
+  playbackSpeed.value = event.payload.playback_speed ?? 1.0
 })
 
 listen('reload-track-id', async event => {
@@ -92,17 +94,23 @@ export function usePlayer() {
     invoke('set_volume', { volume })
   }
 
+  const setPlaybackSpeed = playbackSpeedValue => {
+    invoke('set_playback_speed', { playbackSpeed: playbackSpeedValue })
+  }
+
   return {
     playingTrack,
     status,
     duration,
     progress,
     volume,
+    playbackSpeed,
     playTrack,
     pause,
     resume,
     stop,
     seek,
     setVolume,
+    setPlaybackSpeed,
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -106,6 +106,29 @@ body {
   @apply dark:bg-neutral-800;
 }
 
+.select {
+  @apply box-border border border-neutral-300 rounded transition outline-none text-neutral-900 bg-white px-2 py-1 pr-6 text-sm
+  dark:border-neutral-600 dark:text-neutral-100 dark:bg-neutral-800;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M6 8l4 4 4-4' stroke='%23525252' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.4rem center;
+  background-size: 0.9rem;
+}
+
+.dark .select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M6 8l4 4 4-4' stroke='%23d4d4d4' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+.select option {
+  @apply text-neutral-900 bg-white dark:text-neutral-100 dark:bg-neutral-800;
+}
+
+.select-xs {
+  @apply text-xs px-1.5 pr-6 py-0.5;
+}
+
 .textarea {
   @apply bg-white box-border border border-neutral-300 focus:border-hoa-1100 outline-none
   text-sm rounded-lg transition text-neutral-900 placeholder:text-neutral-400 resize-none


### PR DESCRIPTION
Hi, it's my first contribution to this project, but I have used it quite a lot. I really like the new lyrics synchonization interface (though I thought it was quite a bit rough around the edges), and I made some big changes to, mainly, the word sync interface (added keyboard commands and whatnot).

This kind of expanded to a bigger change in the shortcut menu system however, because I found the shortcuts a bit hard to maintain. So here are the changes:

### Shortcut System Changes

Made Shortcut keyboard reference be opened via `Ctrl + /`.

As I was already making major changes to the shortcut system anyway, I added a way to be able to rebind shortcuts:

<img width="701" height="175" alt="image" src="https://github.com/user-attachments/assets/748af544-ca33-495c-8a14-3b3c31880f4a" />

And button shortcut hints:

<img width="531" height="152" alt="image" src="https://github.com/user-attachments/assets/eea9ed38-4063-49c0-b5bb-b275a627e29a" />

https://github.com/user-attachments/assets/04ee8a26-3d78-4a33-8a06-d845253bbd16

All shortcuts are now configured from `src\composables\edit-lyrics-v2\shortcutRegistry.js`, and have an ID:

<img width="1234" height="581" alt="image" src="https://github.com/user-attachments/assets/504cb9e1-abcc-42df-a3dd-ebd284b1d8f8" />

It checks if any registered bindings match and registers an action run.
<img width="870" height="627" alt="image" src="https://github.com/user-attachments/assets/3e99d9c3-387f-4631-8880-ffb46c78c916" />

should fix #348 (I think there was already some shortcut modal code implemented, so it's more like a little extra too).

### Playback Speed Control

To help with editing words, sometimes slowing down playback is a must. There is now a speed selector implemented here:
<img width="1048" height="221" alt="image" src="https://github.com/user-attachments/assets/e91ed9ca-52aa-4112-aa80-9819c5379848" />

and here

<img width="1548" height="308" alt="image" src="https://github.com/user-attachments/assets/ccb791ce-c10f-4610-b806-53cdcb1840eb" />

these are the options for now, but any interface for selecting a speed should work:

<img width="290" height="282" alt="image" src="https://github.com/user-attachments/assets/03827da4-541a-44bb-a607-b58f2c8fd2b4" />

https://github.com/user-attachments/assets/9f2e29b0-5a0e-42d2-b9b6-29962bb41282

should fix #79, #266

### Word Sync Interface Improvements

The interface has now some changes in how it works. Before, it was mostly by dragging the segment dividers. That is still possible, but now there are shortcuts for syncing words:

<img width="392" height="653" alt="image" src="https://github.com/user-attachments/assets/758bd583-b5d7-40fc-a249-f9c6f9002bce" />

Made some changes so the default `enter` shortcut also syncs last line end, unless explicitly using `shift-enter`. This felt more natural, as you don't expect that changing your current line can make it overlap with the previous one. Word shortcuts work as following:

1. By default, when a line is selected, the second divider (between the first and second words) is selected. Every time you press `Z` (by default), it syncs the divider to the current playback time and selects the next divider. The bottom hint for the next word was added for times when segments are too small to render properly. Here is an example of how you would sync a line:

https://github.com/user-attachments/assets/c135e7c6-71b4-4098-b88e-1cab239db0a1

2. You can use `X` (by default) to move your cursor back to the second divider, and `Shift-P` to restart from the last line to have some time to prepare.

Using these shortcuts, you can sync the words by clicking `Z` in the rhythm.

Made some changes to the segment display as well, in two major ways, other than the hint for next segment:

1. Smart segmentation - Many languages, such as japanese, chinese, arabic, and korean do not use spaces or any dividers whatsoever to separate word segments. Previously, segmentation just split all characters individually for these, which made syncing completely impractical. I have added https://crates.io/crates/charabia for intelligent international segmentation. It smartly detects and splits the line into actual relevant segments:
<img width="995" height="362" alt="image" src="https://github.com/user-attachments/assets/b20e3229-32e4-48b8-a80d-4272eca5f298" />

Should fix #345 and #344.

2. Segment Editing: Some lyrics will still be segmented incorrectly, or you may want to join/split segments depending on how you are syncing it (a word may be sung fast in its beginning but drag its end, etc). For these situations, I have added the delete key (it deletes the currently selected divider and merges the two segments on its sides; and a segment splitting function. You hover where on the word you want to split it, double click, and it becomes two disjoint segments:

https://github.com/user-attachments/assets/b92a0343-4daf-4ab4-9ab9-333a71a93296

Finally, made some minor ajustments to displaying lines. End times are always displayed, but only if the line's end time is different from the start of the next line. While not that useful for lines that finish before the next line begins, Its a good indicator to see at a glance overlapped lines, which happens sometimes when there is a secondary voice or multiple singers (reds are overlaps, yellows finish early):

<img width="908" height="316" alt="image" src="https://github.com/user-attachments/assets/0746f4ad-7a59-4675-96f1-e993cb0483c9" />

https://github.com/user-attachments/assets/3c437832-6c31-4f16-9974-8b75cbbc1b74

These are the changes I have made so far. I have actually implemented a simple eLRC export method as well, but that one can be a separate pull request.

If there is any changes you thing would be good to make to the interface, please tell me. Life is a bit busy, so I don't guarantee lightning fast responses, but I think I can work on it a bit if necessary. Will keep as a draft for now, if I find any changes I want to make from my side as well.