### PR TITLE
feat(editor): Allow exporting lyricsfiles to disk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4300,11 +4300,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-<<<<<<< HEAD
       "license": "MIT",
       "peer": true,
-=======
->>>>>>> 3493d3a (generated first pass)
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8247,16 +8244,10 @@
       }
     },
     "postcss": {
-<<<<<<< HEAD
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "peer": true,
-=======
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
->>>>>>> 3493d3a (generated first pass)
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,7 +2064,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2252,7 +2251,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -2344,7 +2342,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
-      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -2902,7 +2899,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3315,7 +3311,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
       "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -3552,7 +3547,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4306,8 +4300,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+<<<<<<< HEAD
       "license": "MIT",
       "peer": true,
+=======
+>>>>>>> 3493d3a (generated first pass)
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5176,7 +5173,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
       "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.16",
@@ -5470,7 +5466,6 @@
       "version": "3.5.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.10.tgz",
       "integrity": "sha512-Vy2kmJwHPlouC/tSnIgXVg03SG+9wSqT1xu1Vehc+ChsXsRd7jLkKgMltVEFOzUdBr3uFwBCG+41LJtfAcBRng==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.10",
         "@vue/compiler-sfc": "3.5.10",
@@ -6883,8 +6878,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -7000,7 +6994,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -7057,7 +7050,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
-      "peer": true,
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -7377,7 +7369,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7654,7 +7645,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
       "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
-      "peer": true,
       "requires": {
         "tabbable": "^6.2.0"
       }
@@ -7811,8 +7801,7 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -8258,10 +8247,16 @@
       }
     },
     "postcss": {
+<<<<<<< HEAD
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "peer": true,
+=======
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+>>>>>>> 3493d3a (generated first pass)
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8787,7 +8782,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
       "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",
@@ -8883,7 +8877,6 @@
       "version": "3.5.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.10.tgz",
       "integrity": "sha512-Vy2kmJwHPlouC/tSnIgXVg03SG+9wSqT1xu1Vehc+ChsXsRd7jLkKgMltVEFOzUdBr3uFwBCG+41LJtfAcBRng==",
-      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.5.10",
         "@vue/compiler-sfc": "3.5.10",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["tranxuanthang"]
 license = "MIT"
 repository = "https://github.com/tranxuanthang/lrcget"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.89"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -12,7 +12,7 @@ use lofty::id3::v2::{
 use lofty::mpeg::MpegFile;
 use lofty::TextEncoding;
 use serde::Serialize;
-use std::fs::{remove_file, write};
+use std::fs::write;
 use std::io::Seek;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -45,25 +45,6 @@ pub enum ExportFormat {
     Lyricsfile,
     /// Embedded in audio file metadata
     Embedded,
-}
-
-/// Sidecar formats that share a basename with the audio file. Embedded is not
-/// listed here because it does not produce a separate file. Used by
-/// `remove_other_sidecars` to enforce the "only one sidecar at a time" invariant
-/// from the export UI as a defense-in-depth at write time.
-const SIDECAR_EXTENSIONS: &[&str] = &["txt", "lrc", "yaml"];
-
-/// Remove any sidecar files (`.txt`, `.lrc`, `.yaml`) sharing the audio file's
-/// basename, except the one whose extension is being written next.
-fn remove_other_sidecars(track_path: &str, keep_ext: &str) {
-    for ext in SIDECAR_EXTENSIONS {
-        if *ext == keep_ext {
-            continue;
-        }
-        if let Ok(path) = build_sidecar_path(track_path, ext) {
-            let _ = remove_file(path);
-        }
-    }
 }
 
 /// Status of an export operation
@@ -156,9 +137,6 @@ fn export_txt(
 
     let txt_path = build_sidecar_path(&track.file_path, "txt")?;
 
-    // Remove conflicting sidecar files of the other formats (.lrc, .yaml).
-    remove_other_sidecars(&track.file_path, "txt");
-
     write(&txt_path, content).map_err(|e| ExportError::WriteError(e.to_string()))?;
 
     Ok(ExportResult {
@@ -187,9 +165,6 @@ fn export_lrc(
 
     let lrc_path = build_sidecar_path(&track.file_path, "lrc")?;
 
-    // Remove conflicting sidecar files of the other formats (.txt, .yaml).
-    remove_other_sidecars(&track.file_path, "lrc");
-
     write(&lrc_path, content).map_err(|e| ExportError::WriteError(e.to_string()))?;
 
     Ok(ExportResult {
@@ -200,9 +175,6 @@ fn export_lrc(
 }
 
 /// Export Lyricsfile YAML to a `.yaml` sidecar. The YAML is written verbatim
-/// (preserving any word-level timing or LRCLIB-provided metadata) and the
-/// sibling `.txt` / `.lrc` files are removed to keep a single sidecar variant
-/// on disk per track.
 fn export_lyricsfile(
     track: &PersistentTrack,
     raw_lyricsfile: &str,
@@ -217,9 +189,6 @@ fn export_lyricsfile(
     }
 
     let yaml_path = build_sidecar_path(&track.file_path, "yaml")?;
-
-    // Remove conflicting sidecar files of the other formats (.txt, .lrc).
-    remove_other_sidecars(&track.file_path, "yaml");
 
     write(&yaml_path, raw_lyricsfile).map_err(|e| ExportError::WriteError(e.to_string()))?;
 

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -41,8 +41,29 @@ pub enum ExportFormat {
     Txt,
     /// Standard LRC format (.lrc)
     Lrc,
+    /// Lyricsfile YAML format (.yaml) - preserves word-level timing
+    Lyricsfile,
     /// Embedded in audio file metadata
     Embedded,
+}
+
+/// Sidecar formats that share a basename with the audio file. Embedded is not
+/// listed here because it does not produce a separate file. Used by
+/// `remove_other_sidecars` to enforce the "only one sidecar at a time" invariant
+/// from the export UI as a defense-in-depth at write time.
+const SIDECAR_EXTENSIONS: &[&str] = &["txt", "lrc", "yaml"];
+
+/// Remove any sidecar files (`.txt`, `.lrc`, `.yaml`) sharing the audio file's
+/// basename, except the one whose extension is being written next.
+fn remove_other_sidecars(track_path: &str, keep_ext: &str) {
+    for ext in SIDECAR_EXTENSIONS {
+        if *ext == keep_ext {
+            continue;
+        }
+        if let Ok(path) = build_sidecar_path(track_path, ext) {
+            let _ = remove_file(path);
+        }
+    }
 }
 
 /// Status of an export operation
@@ -105,11 +126,13 @@ pub fn generate_lrc_content(parsed: &ParsedLyricsfile) -> Option<String> {
 pub fn export_track_format(
     track: &PersistentTrack,
     parsed: &ParsedLyricsfile,
+    raw_lyricsfile: &str,
     format: ExportFormat,
 ) -> Result<ExportResult, ExportError> {
     match format {
         ExportFormat::Txt => export_txt(track, parsed),
         ExportFormat::Lrc => export_lrc(track, parsed),
+        ExportFormat::Lyricsfile => export_lyricsfile(track, raw_lyricsfile),
         ExportFormat::Embedded => export_embedded(track, parsed),
     }
 }
@@ -133,11 +156,8 @@ fn export_txt(
 
     let txt_path = build_sidecar_path(&track.file_path, "txt")?;
 
-    // Remove conflicting .lrc file if it exists
-    let lrc_path = build_sidecar_path(&track.file_path, "lrc").ok();
-    if let Some(ref lrc_path) = lrc_path {
-        let _ = remove_file(lrc_path);
-    }
+    // Remove conflicting sidecar files of the other formats (.lrc, .yaml).
+    remove_other_sidecars(&track.file_path, "txt");
 
     write(&txt_path, content).map_err(|e| ExportError::WriteError(e.to_string()))?;
 
@@ -167,17 +187,45 @@ fn export_lrc(
 
     let lrc_path = build_sidecar_path(&track.file_path, "lrc")?;
 
-    // Remove conflicting .txt file if it exists
-    let txt_path = build_sidecar_path(&track.file_path, "txt").ok();
-    if let Some(ref txt_path) = txt_path {
-        let _ = remove_file(txt_path);
-    }
+    // Remove conflicting sidecar files of the other formats (.txt, .yaml).
+    remove_other_sidecars(&track.file_path, "lrc");
 
     write(&lrc_path, content).map_err(|e| ExportError::WriteError(e.to_string()))?;
 
     Ok(ExportResult {
         format: ExportFormat::Lrc,
         path: Some(lrc_path),
+        status: ExportStatus::Success,
+    })
+}
+
+/// Export Lyricsfile YAML to a `.yaml` sidecar. The YAML is written verbatim
+/// (preserving any word-level timing or LRCLIB-provided metadata) and the
+/// sibling `.txt` / `.lrc` files are removed to keep a single sidecar variant
+/// on disk per track.
+fn export_lyricsfile(
+    track: &PersistentTrack,
+    raw_lyricsfile: &str,
+) -> Result<ExportResult, ExportError> {
+    let trimmed = raw_lyricsfile.trim();
+    if trimmed.is_empty() {
+        return Ok(ExportResult {
+            format: ExportFormat::Lyricsfile,
+            path: None,
+            status: ExportStatus::Skipped("no lyricsfile content available".to_string()),
+        });
+    }
+
+    let yaml_path = build_sidecar_path(&track.file_path, "yaml")?;
+
+    // Remove conflicting sidecar files of the other formats (.txt, .lrc).
+    remove_other_sidecars(&track.file_path, "yaml");
+
+    write(&yaml_path, raw_lyricsfile).map_err(|e| ExportError::WriteError(e.to_string()))?;
+
+    Ok(ExportResult {
+        format: ExportFormat::Lyricsfile,
+        path: Some(yaml_path),
         status: ExportStatus::Success,
     })
 }
@@ -208,12 +256,13 @@ fn export_embedded(
 pub fn export_track(
     track: &PersistentTrack,
     parsed: &ParsedLyricsfile,
+    raw_lyricsfile: &str,
     formats: &[ExportFormat],
 ) -> Vec<ExportResult> {
     let mut results = Vec::with_capacity(formats.len());
 
     for format in formats {
-        match export_track_format(track, parsed, *format) {
+        match export_track_format(track, parsed, raw_lyricsfile, *format) {
             Ok(result) => results.push(result),
             Err(e) => results.push(ExportResult {
                 format: *format,
@@ -392,6 +441,37 @@ mod tests {
 
         let lrc_path = build_sidecar_path(track_path, "lrc").unwrap();
         assert_eq!(lrc_path.to_str().unwrap(), "/music/artist/album/song.lrc");
+
+        let yaml_path = build_sidecar_path(track_path, "yaml").unwrap();
+        assert_eq!(yaml_path.to_str().unwrap(), "/music/artist/album/song.yaml");
+    }
+
+    #[test]
+    fn test_export_lyricsfile_skips_empty_content() {
+        let track = PersistentTrack {
+            id: 1,
+            file_path: "/music/artist/album/song.mp3".to_string(),
+            file_name: "song.mp3".to_string(),
+            title: "Song".to_string(),
+            album_name: "Album".to_string(),
+            album_artist_name: None,
+            album_id: 1,
+            artist_name: "Artist".to_string(),
+            artist_id: 1,
+            image_path: None,
+            track_number: None,
+            txt_lyrics: None,
+            lrc_lyrics: None,
+            lyricsfile: None,
+            lyricsfile_id: None,
+            duration: 0.0,
+            instrumental: false,
+        };
+
+        let result = export_lyricsfile(&track, "   \n\t  ").unwrap();
+        assert!(matches!(result.format, ExportFormat::Lyricsfile));
+        assert!(result.path.is_none());
+        assert!(matches!(result.status, ExportStatus::Skipped(_)));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -53,6 +53,7 @@ struct FlagLyricsProgress {
 enum ExportLyricsFormat {
     Txt,
     Lrc,
+    Yaml,
     Embedded,
 }
 
@@ -92,6 +93,7 @@ impl From<ExportLyricsFormat> for export::ExportFormat {
         match value {
             ExportLyricsFormat::Txt => export::ExportFormat::Txt,
             ExportLyricsFormat::Lrc => export::ExportFormat::Lrc,
+            ExportLyricsFormat::Yaml => export::ExportFormat::Lyricsfile,
             ExportLyricsFormat::Embedded => export::ExportFormat::Embedded,
         }
     }
@@ -1235,7 +1237,12 @@ async fn export_lyrics(
         lyricsfile::parse_lyricsfile(&lyricsfile_content).map_err(|err| err.to_string())?;
     let export_formats = formats.into_iter().map(Into::into).collect::<Vec<_>>();
 
-    Ok(export::export_track(&track, &parsed, &export_formats))
+    Ok(export::export_track(
+        &track,
+        &parsed,
+        &lyricsfile_content,
+        &export_formats,
+    ))
 }
 
 /// Detail for a single format export result
@@ -1296,11 +1303,12 @@ async fn export_track_lyrics(
         });
     }
 
-    let parsed = lyricsfile::parse_lyricsfile(&lyricsfile_content.unwrap())
-        .map_err(|err| err.to_string())?;
+    let raw_lyricsfile = lyricsfile_content.unwrap();
+    let parsed =
+        lyricsfile::parse_lyricsfile(&raw_lyricsfile).map_err(|err| err.to_string())?;
     let export_formats = formats.into_iter().map(Into::into).collect::<Vec<_>>();
 
-    let results = export::export_track(&track, &parsed, &export_formats);
+    let results = export::export_track(&track, &parsed, &raw_lyricsfile, &export_formats);
 
     // Count results based on status
     let exported = results

--- a/src-tauri/src/scanner/metadata.rs
+++ b/src-tauri/src/scanner/metadata.rs
@@ -25,6 +25,9 @@ pub struct TrackMetadata {
 pub struct LyricsInfo {
     pub txt_lyrics: Option<String>,
     pub lrc_lyrics: Option<String>,
+    /// Raw Lyricsfile YAML content from a sibling `<stem>.yaml` file, if present.
+    /// Takes precedence over `txt_lyrics`/`lrc_lyrics` when it parses successfully.
+    pub yaml_lyricsfile: Option<String>,
 }
 
 /// Errors that can occur during metadata extraction
@@ -113,25 +116,27 @@ impl TrackMetadata {
 }
 
 impl LyricsInfo {
-    /// Extract lyrics from external files (.txt and .lrc)
+    /// Extract lyrics from external sidecar files (.txt, .lrc, .yaml)
     pub fn from_path(path: &Path) -> Self {
         let mut result = LyricsInfo::default();
 
-        // Get file stem (filename without extension)
         let file_stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
 
         let parent_path = path.parent().unwrap_or(Path::new("."));
 
-        // Try to read .txt lyrics
         let txt_path = parent_path.join(format!("{}.txt", file_stem));
         if let Ok(content) = std::fs::read_to_string(&txt_path) {
             result.txt_lyrics = Some(content);
         }
 
-        // Try to read .lrc lyrics
         let lrc_path = parent_path.join(format!("{}.lrc", file_stem));
         if let Ok(content) = std::fs::read_to_string(&lrc_path) {
             result.lrc_lyrics = Some(content);
+        }
+
+        let yaml_path = parent_path.join(format!("{}.yaml", file_stem));
+        if let Ok(content) = std::fs::read_to_string(&yaml_path) {
+            result.yaml_lyricsfile = Some(content);
         }
 
         result

--- a/src-tauri/src/scanner/scan.rs
+++ b/src-tauri/src/scanner/scan.rs
@@ -1,6 +1,6 @@
 use crate::db;
 use crate::db::ScanTrackInfo;
-use crate::lyricsfile::{build_lyricsfile, LyricsfileTrackMetadata};
+use crate::lyricsfile::{build_lyricsfile, parse_lyricsfile, LyricsfileTrackMetadata};
 use crate::scanner::hasher::compute_quick_hash;
 use crate::scanner::metadata::extract_track_info;
 use crate::scanner::models::{ScanProgress, ScanResult};
@@ -292,26 +292,48 @@ fn insert_new_track(
         // Reattach orphaned lyricsfile to this track
         db::reattach_lyricsfile_to_track_tx(lyricsfile_id, track_id, tx)?;
     } else {
-        // No orphaned lyricsfile found, import embedded lyrics as usual
-        let lyricsfile_track_metadata = LyricsfileTrackMetadata::new(
-            &metadata.title,
-            &metadata.album,
-            &metadata.artist,
-            metadata.duration,
-        );
+        // Prefer a sibling .yaml Lyricsfile when present and parseable.
+        // On parse failure we fall back to building one from .txt/.lrc so a
+        // malformed YAML doesn't lose lyrics that are also available in the
+        // legacy formats.
+        let yaml_lyricsfile = lyrics
+            .yaml_lyricsfile
+            .as_deref()
+            .and_then(|content| match parse_lyricsfile(content) {
+                Ok(_) => Some(content.to_owned()),
+                Err(err) => {
+                    eprintln!(
+                        "Failed to parse .yaml Lyricsfile next to {:?} ({}); falling back to .lrc/.txt",
+                        path, err
+                    );
+                    None
+                }
+            });
 
-        if let Some(lyricsfile) = build_lyricsfile(
-            &lyricsfile_track_metadata,
-            lyrics.txt_lyrics.as_deref(),
-            lyrics.lrc_lyrics.as_deref(),
-        ) {
+        let lyricsfile_to_store = if let Some(content) = yaml_lyricsfile {
+            Some(content)
+        } else {
+            let lyricsfile_track_metadata = LyricsfileTrackMetadata::new(
+                &metadata.title,
+                &metadata.album,
+                &metadata.artist,
+                metadata.duration,
+            );
+            build_lyricsfile(
+                &lyricsfile_track_metadata,
+                lyrics.txt_lyrics.as_deref(),
+                lyrics.lrc_lyrics.as_deref(),
+            )
+        };
+
+        if let Some(content) = lyricsfile_to_store {
             db::upsert_lyricsfile_for_track_tx(
                 track_id,
                 &metadata.title,
                 &metadata.album,
                 &metadata.artist,
                 metadata.duration,
-                &lyricsfile,
+                &content,
                 tx,
             )?;
         }

--- a/src/components/library/EditLyricsV2.vue
+++ b/src/components/library/EditLyricsV2.vue
@@ -127,6 +127,7 @@
         @add-line-at="addSyncedLineAt"
         @import-lines-from-plain="importSyncedLinesFromPlain"
         @import-lrc-file="handleImportLrcFile"
+        @import-lyricsfile="handleImportLyricsfile"
         @paste-lrc="handlePasteLrc"
         @update:words="updateLineWords"
         @word-timing-edited="handleWordTimingEdited"
@@ -246,6 +247,7 @@ const {
   rewindEndBy100,
   forwardEndBy100,
   saveLyrics,
+  loadFromLyricsfile,
   ensureSelectedSyncedLine,
   updateLineText,
   setInstrumental,
@@ -369,6 +371,36 @@ const handleImportLrcFile = async () => {
   } catch (error) {
     console.error(error)
     toast.error(error?.toString?.() || 'Failed to import LRC file')
+  }
+}
+
+const handleImportLyricsfile = async () => {
+  try {
+    const filePath = await open({
+      multiple: false,
+      directory: false,
+      filters: [
+        { name: 'Lyricsfile', extensions: ['yaml', 'yml'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    })
+
+    if (!filePath) {
+      return
+    }
+
+    const content = await invoke('read_text_file', { filePath })
+    const loaded = loadFromLyricsfile(content)
+
+    if (!loaded) {
+      toast.error('Selected file is not a valid Lyricsfile')
+      return
+    }
+
+    toast.success('Lyricsfile imported')
+  } catch (error) {
+    console.error(error)
+    toast.error(error?.toString?.() || 'Failed to import Lyricsfile')
   }
 }
 

--- a/src/components/library/EditLyricsV2.vue
+++ b/src/components/library/EditLyricsV2.vue
@@ -129,6 +129,7 @@
         @import-lrc-file="handleImportLrcFile"
         @import-lyricsfile="handleImportLyricsfile"
         @paste-lrc="handlePasteLrc"
+        @clear-all-timings="handleClearAllTimings"
         @update:words="updateLineWords"
         @word-timing-edited="handleWordTimingEdited"
         @update-line-text="handleUpdateLineText"
@@ -425,6 +426,15 @@ const handlePasteLrc = async () => {
     console.error(error)
     toast.error(error?.toString?.() || 'Failed to paste LRC from clipboard')
   }
+}
+
+const handleClearAllTimings = () => {
+  if (syncedLines.value.length === 0) {
+    return
+  }
+
+  updateSyncedLines([])
+  toast.success('Cleared all timings')
 }
 
 const handleWordTimingEdited = async ({ startMs }) => {

--- a/src/components/library/LibraryHeader.vue
+++ b/src/components/library/LibraryHeader.vue
@@ -143,22 +143,44 @@
             <div class="dropdown-section-label">Export all lyrics to tracks' directory:</div>
 
             <label class="dropdown-item">
-              <CheckboxButton
-                id="export-plain-text"
-                v-model="exportPlainText"
-                name="export-plain-text"
+              <RadioButton
+                id="export-sidecar-none"
+                v-model="sidecarFormat"
+                value=""
+                name="export-sidecar-format"
               >
-                <span class="dropdown-label">Plain lyrics (.txt)</span>
-              </CheckboxButton>
+                <span class="dropdown-label">No sidecar file</span>
+              </RadioButton>
             </label>
             <label class="dropdown-item">
-              <CheckboxButton
-                id="export-synced-lrc"
-                v-model="exportSyncedLrc"
-                name="export-synced-lrc"
+              <RadioButton
+                id="export-sidecar-txt"
+                v-model="sidecarFormat"
+                value="txt"
+                name="export-sidecar-format"
+              >
+                <span class="dropdown-label">Plain lyrics (.txt)</span>
+              </RadioButton>
+            </label>
+            <label class="dropdown-item">
+              <RadioButton
+                id="export-sidecar-lrc"
+                v-model="sidecarFormat"
+                value="lrc"
+                name="export-sidecar-format"
               >
                 <span class="dropdown-label">Synced lyrics (.lrc)</span>
-              </CheckboxButton>
+              </RadioButton>
+            </label>
+            <label class="dropdown-item">
+              <RadioButton
+                id="export-sidecar-yaml"
+                v-model="sidecarFormat"
+                value="yaml"
+                name="export-sidecar-format"
+              >
+                <span class="dropdown-label">Lyricsfile (.yaml)</span>
+              </RadioButton>
             </label>
 
             <label
@@ -236,6 +258,7 @@ import Refresh from '~icons/mdi/refresh'
 import FolderMultiple from '~icons/mdi/folder-multiple'
 import Export from '~icons/mdi/export'
 import CheckboxButton from '@/components/common/CheckboxButton.vue'
+import RadioButton from '@/components/common/RadioButton.vue'
 import { useDownloader } from '@/composables/downloader.js'
 import { useExporter } from '@/composables/export.js'
 import MiniSearch from './MiniSearch.vue'
@@ -253,8 +276,7 @@ const emit = defineEmits([
   'showExportViewer',
 ])
 
-const exportPlainText = ref(false)
-const exportSyncedLrc = ref(false)
+const sidecarFormat = ref('')
 const embedIntoTrack = ref(false)
 const tryEmbedLyrics = ref(false)
 
@@ -266,7 +288,7 @@ const refreshEmbedConfig = async () => {
 onMounted(refreshEmbedConfig)
 
 const hasSelectedExportFormat = computed(
-  () => exportPlainText.value || exportSyncedLrc.value || embedIntoTrack.value
+  () => sidecarFormat.value !== '' || embedIntoTrack.value
 )
 
 const handleExportClick = () => {
@@ -275,8 +297,7 @@ const handleExportClick = () => {
   }
 
   emit('exportAllLyrics', {
-    plainText: exportPlainText.value,
-    syncedLrc: exportSyncedLrc.value,
+    sidecarFormat: sidecarFormat.value,
     embedIntoTrack: embedIntoTrack.value,
   })
 }

--- a/src/components/library/LibraryHeader.vue
+++ b/src/components/library/LibraryHeader.vue
@@ -144,16 +144,6 @@
 
             <label class="dropdown-item">
               <RadioButton
-                id="export-sidecar-none"
-                v-model="sidecarFormat"
-                value=""
-                name="export-sidecar-format"
-              >
-                <span class="dropdown-label">No sidecar file</span>
-              </RadioButton>
-            </label>
-            <label class="dropdown-item">
-              <RadioButton
                 id="export-sidecar-txt"
                 v-model="sidecarFormat"
                 value="txt"

--- a/src/components/library/edit-lyrics-v2/EditLyricsV2HeaderActions.vue
+++ b/src/components/library/edit-lyrics-v2/EditLyricsV2HeaderActions.vue
@@ -46,16 +46,6 @@
 
             <label class="dropdown-item">
               <RadioButton
-                id="editor-export-sidecar-none"
-                v-model="sidecarFormat"
-                value=""
-                name="editor-export-sidecar-format"
-              >
-                <span class="dropdown-label">No sidecar file</span>
-              </RadioButton>
-            </label>
-            <label class="dropdown-item">
-              <RadioButton
                 id="editor-export-sidecar-txt"
                 v-model="sidecarFormat"
                 value="txt"

--- a/src/components/library/edit-lyrics-v2/EditLyricsV2HeaderActions.vue
+++ b/src/components/library/edit-lyrics-v2/EditLyricsV2HeaderActions.vue
@@ -45,22 +45,44 @@
             <div class="dropdown-section-label">Export to track's directory:</div>
 
             <label class="dropdown-item">
-              <CheckboxButton
-                id="export-plain-text"
-                v-model="exportPlainText"
-                name="export-plain-text"
+              <RadioButton
+                id="editor-export-sidecar-none"
+                v-model="sidecarFormat"
+                value=""
+                name="editor-export-sidecar-format"
               >
-                <span class="dropdown-label">Plain lyrics (.txt)</span>
-              </CheckboxButton>
+                <span class="dropdown-label">No sidecar file</span>
+              </RadioButton>
             </label>
             <label class="dropdown-item">
-              <CheckboxButton
-                id="export-synced-lrc"
-                v-model="exportSyncedLrc"
-                name="export-synced-lrc"
+              <RadioButton
+                id="editor-export-sidecar-txt"
+                v-model="sidecarFormat"
+                value="txt"
+                name="editor-export-sidecar-format"
+              >
+                <span class="dropdown-label">Plain lyrics (.txt)</span>
+              </RadioButton>
+            </label>
+            <label class="dropdown-item">
+              <RadioButton
+                id="editor-export-sidecar-lrc"
+                v-model="sidecarFormat"
+                value="lrc"
+                name="editor-export-sidecar-format"
               >
                 <span class="dropdown-label">Synced lyrics (.lrc)</span>
-              </CheckboxButton>
+              </RadioButton>
+            </label>
+            <label class="dropdown-item">
+              <RadioButton
+                id="editor-export-sidecar-yaml"
+                v-model="sidecarFormat"
+                value="yaml"
+                name="editor-export-sidecar-format"
+              >
+                <span class="dropdown-label">Lyricsfile (.yaml)</span>
+              </RadioButton>
             </label>
 
             <label
@@ -117,12 +139,12 @@ import ChevronDown from '~icons/mdi/chevron-down'
 import ContentSave from '~icons/mdi/content-save'
 import Bug from '~icons/mdi/bug'
 import CheckboxButton from '@/components/common/CheckboxButton.vue'
+import RadioButton from '@/components/common/RadioButton.vue'
 import { invoke } from '@tauri-apps/api/core'
 
 const emit = defineEmits(['save', 'save-and-publish', 'export', 'debug'])
 
-const exportPlainText = ref(false)
-const exportSyncedLrc = ref(false)
+const sidecarFormat = ref('')
 const embedIntoTrack = ref(false)
 const tryEmbedLyrics = ref(false)
 
@@ -134,7 +156,7 @@ const refreshEmbedConfig = async () => {
 onMounted(refreshEmbedConfig)
 
 const hasSelectedExportFormat = computed(
-  () => exportPlainText.value || exportSyncedLrc.value || embedIntoTrack.value
+  () => sidecarFormat.value !== '' || embedIntoTrack.value
 )
 
 const handleExportClick = () => {
@@ -143,8 +165,7 @@ const handleExportClick = () => {
   }
 
   emit('export', {
-    plainText: exportPlainText.value,
-    syncedLrc: exportSyncedLrc.value,
+    sidecarFormat: sidecarFormat.value,
     embedIntoTrack: embedIntoTrack.value,
   })
 }

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
@@ -117,6 +117,7 @@
       :can-import-from-plain="canImportFromPlain"
       @import-lines-from-plain="handleImportLinesFromPlain"
       @import-lrc-file="emit('import-lrc-file')"
+      @import-lyricsfile="emit('import-lyricsfile')"
       @paste-lrc="emit('paste-lrc')"
       @add-line-at="handleAddLineAt"
       @mark-as-instrumental="handleMarkAsInstrumental"
@@ -179,6 +180,7 @@ const emit = defineEmits([
   'add-line-at',
   'import-lines-from-plain',
   'import-lrc-file',
+  'import-lyricsfile',
   'paste-lrc',
   'editing-state-change',
   'update:words',

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsEditor.vue
@@ -12,6 +12,9 @@
       @play-line="handlePlayLine"
       @play-line-at-offset="handlePlayLineAtOffset"
       @select-next-line="selectLine"
+      @import-lrc-file="emit('import-lrc-file')"
+      @import-lyricsfile="emit('import-lyricsfile')"
+      @clear-all-timings="emit('clear-all-timings')"
     />
 
     <div
@@ -187,6 +190,7 @@ const emit = defineEmits([
   'word-timing-edited',
   'update-line-text',
   'mark-as-instrumental',
+  'clear-all-timings',
 ])
 
 const hoveredLineIndex = ref(null)

--- a/src/components/library/edit-lyrics-v2/SyncedLyricsEmptyState.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedLyricsEmptyState.vue
@@ -25,6 +25,12 @@
         </button>
         <button
           class="button button-normal px-2 py-1 text-xs rounded-full"
+          @click="emit('import-lyricsfile')"
+        >
+          Import Lyricsfile
+        </button>
+        <button
+          class="button button-normal px-2 py-1 text-xs rounded-full"
           @click="emit('paste-lrc')"
         >
           Paste LRC content
@@ -54,5 +60,12 @@ defineProps({
   },
 })
 
-const emit = defineEmits(['import-lines-from-plain', 'import-lrc-file', 'paste-lrc', 'add-line-at', 'mark-as-instrumental'])
+const emit = defineEmits([
+  'import-lines-from-plain',
+  'import-lrc-file',
+  'import-lyricsfile',
+  'paste-lrc',
+  'add-line-at',
+  'mark-as-instrumental',
+])
 </script>

--- a/src/components/library/edit-lyrics-v2/SyncedWordTimingLane.vue
+++ b/src/components/library/edit-lyrics-v2/SyncedWordTimingLane.vue
@@ -66,6 +66,33 @@
             <Close class="w-3.5 h-3.5" />
             <span>Reset</span>
           </button>
+          <VDropdown theme="lrcget-dropdown" placement="bottom-end">
+            <button
+              class="button button-normal text-xs px-1.5 py-1 rounded flex items-center"
+              title="More actions"
+              type="button"
+            >
+              <DotsVertical class="w-3.5 h-3.5" />
+            </button>
+
+            <template #popper>
+              <div class="dropdown-container">
+                <button v-close-popper class="dropdown-item" @click="handleImportLrcFile">
+                  <FileMusicOutline class="text-neutral-800 dark:text-neutral-300" />
+                  <span class="dropdown-label">Import LRC file</span>
+                </button>
+                <button v-close-popper class="dropdown-item" @click="handleImportLyricsfile">
+                  <FileDocumentOutline class="text-neutral-800 dark:text-neutral-300" />
+                  <span class="dropdown-label">Import Lyricsfile</span>
+                </button>
+                <div class="dropdown-divider" />
+                <button v-close-popper class="dropdown-item" @click="handleClearAllTimings">
+                  <DeleteSweepOutline class="text-neutral-800 dark:text-neutral-300" />
+                  <span class="dropdown-label">Clear all timings</span>
+                </button>
+              </div>
+            </template>
+          </VDropdown>
         </div>
       </div>
 
@@ -160,6 +187,10 @@ import { invoke } from '@tauri-apps/api/core'
 import Equal from '~icons/mdi/equal'
 import Play from '~icons/mdi/play'
 import Close from '~icons/mdi/close'
+import DotsVertical from '~icons/mdi/dots-vertical'
+import FileMusicOutline from '~icons/mdi/file-music-outline'
+import FileDocumentOutline from '~icons/mdi/file-document-outline'
+import DeleteSweepOutline from '~icons/mdi/delete-sweep-outline'
 import SyncedWordTimingSegment from '@/components/library/edit-lyrics-v2/SyncedWordTimingSegment.vue'
 import { useEditLyricsV2WordBoundaryDrag } from '@/composables/edit-lyrics-v2/useEditLyricsV2WordBoundaryDrag.js'
 import { useEditLyricsV2WordTimingHotkeys } from '@/composables/edit-lyrics-v2/useEditLyricsV2WordTimingHotkeys.js'
@@ -194,7 +225,15 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['update:words', 'word-timing-edited', 'play-line', 'select-next-line'])
+const emit = defineEmits([
+  'update:words',
+  'word-timing-edited',
+  'play-line',
+  'select-next-line',
+  'import-lrc-file',
+  'import-lyricsfile',
+  'clear-all-timings',
+])
 
 const timelineElement = ref(null)
 const timelineWidth = ref(0)
@@ -588,6 +627,18 @@ const handleResetWords = async () => {
   await loadDefaultSegmentation({ force: true })
 }
 
+const handleImportLrcFile = () => {
+  emit('import-lrc-file')
+}
+
+const handleImportLyricsfile = () => {
+  emit('import-lyricsfile')
+}
+
+const handleClearAllTimings = () => {
+  emit('clear-all-timings')
+}
+
 const handleTimelineClick = event => {
   event.stopPropagation()
 }
@@ -672,3 +723,21 @@ onUnmounted(() => {
   unbindWordTimingHotkeys()
 })
 </script>
+
+<style scoped>
+.dropdown-container {
+  @apply p-1 min-w-[12rem];
+}
+
+.dropdown-item {
+  @apply flex items-center px-2 py-1 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded cursor-pointer h-8 gap-2 w-full;
+}
+
+.dropdown-divider {
+  @apply h-px bg-neutral-100 dark:bg-neutral-700 my-1;
+}
+
+.dropdown-label {
+  @apply text-neutral-800 dark:text-neutral-300 text-sm font-bold;
+}
+</style>

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2Document.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2Document.js
@@ -111,6 +111,24 @@ export function useEditLyricsV2Document({ audioSource, lyricsfile, trackId, prog
     ensureSelectedSyncedLine()
   }
 
+  const loadFromLyricsfile = lyricsfileContent => {
+    const parsed = parseLyricsfile(lyricsfileContent)
+
+    if (!parsed.document) {
+      return false
+    }
+
+    plainLyrics.value = parsed.plainLyrics
+    syncedLines.value = parsed.syncedLines.map(line => normalizeSyncedLine(line))
+    isInstrumental.value = parsed.isInstrumental
+    lyricsfileDocument.value = parsed.document
+    isDirty.value = true
+    isSyncedLineEditing.value = false
+    ensureSelectedSyncedLine()
+
+    return true
+  }
+
   const updatePlainLyrics = lyrics => {
     plainLyrics.value = lyrics
     // Plain and synced lyrics are now independent - editing plain lyrics
@@ -472,6 +490,7 @@ export function useEditLyricsV2Document({ audioSource, lyricsfile, trackId, prog
     isInstrumental,
     serializedLyricsfile,
     initializeLyrics,
+    loadFromLyricsfile,
     updatePlainLyrics,
     updateSyncedLines,
     selectSyncedLine,

--- a/src/composables/edit-lyrics-v2/useEditLyricsV2Export.js
+++ b/src/composables/edit-lyrics-v2/useEditLyricsV2Export.js
@@ -4,15 +4,11 @@ import { ref } from 'vue'
 export function useEditLyricsV2Export({ audioSource, saveLyrics, serializedLyricsfile, toast }) {
   const isExporting = ref(false)
 
-  const exportLyrics = async ({ plainText, syncedLrc, embedIntoTrack }) => {
+  const exportLyrics = async ({ sidecarFormat, embedIntoTrack }) => {
     const formats = []
 
-    if (plainText) {
-      formats.push('txt')
-    }
-
-    if (syncedLrc) {
-      formats.push('lrc')
+    if (sidecarFormat) {
+      formats.push(sidecarFormat)
     }
 
     if (embedIntoTrack) {

--- a/src/composables/export.js
+++ b/src/composables/export.js
@@ -11,8 +11,7 @@ const errorCount = ref(0)
 const isExporting = ref(false)
 const totalCount = ref(0)
 const exportFormats = ref({
-  plainText: false,
-  syncedLrc: false,
+  sidecarFormat: '',
   embedIntoTrack: false,
 })
 
@@ -26,8 +25,9 @@ const addLog = logObj => {
 const exportTrack = async track => {
   try {
     const formats = []
-    if (exportFormats.value.plainText) formats.push('txt')
-    if (exportFormats.value.syncedLrc) formats.push('lrc')
+    if (exportFormats.value.sidecarFormat) {
+      formats.push(exportFormats.value.sidecarFormat)
+    }
     if (exportFormats.value.embedIntoTrack) formats.push('embedded')
 
     const result = await invoke('export_track_lyrics', {


### PR DESCRIPTION
## Background

Locally hosted media servers such as Navidrome have the ability to read lyrics information from sidecar files on disk next to media. In the past, these servers have supported reading lrc files like ones retrieved from lrcget, but cannot currently support Lyricsfiles if lrcget does not export them from its internal database.

## Implementation

* Adds option to export lyricsfiles in the editor export menu
* Adds a "Clear all timings" button to quickly reset the entire in-memory synced lyric editor state (and expose the initial state's "import lyricsfile button")
* Changes the behavior of export to avoid removing other non-selected lyric file types while exporting

<img width="959" height="313" alt="image" src="https://github.com/user-attachments/assets/64fb9f85-9a84-49c2-98f7-fc80a71ddbe4" />

<img width="994" height="681" alt="image" src="https://github.com/user-attachments/assets/d506f305-e89e-492b-aa28-4ec9160a6be4" />


## Notes

This PR description is entirely human-authored, but the code for this change was written by Claude Opus. As part of development, I manually tested changes, reviewed the changeset for sanity, and trimmed comments for concision.