### PR TITLE
added fallback for 'artists' tag if 'artist' tag not found.

### DIFF
--- a/src-tauri/ARCHITECTURE.md
+++ b/src-tauri/ARCHITECTURE.md
@@ -380,6 +380,8 @@ struct AudioMetadataResponse {
 
 **Implementation:** Reuses `scanner::metadata::TrackMetadata::from_path()` from the scanning module.
 
+**Artist Fallback:** If the `artist` tag is missing, falls back to the `artists` tag (plural, Vorbis-style), splitting by `;` or `/` delimiters and using the first entry.
+
 ## Search Query Preparation (`prepare_search_query`)
 
 Prepares a search query from track title by:

--- a/src-tauri/src/scanner/metadata.rs
+++ b/src-tauri/src/scanner/metadata.rs
@@ -82,13 +82,23 @@ impl TrackMetadata {
             })?
             .to_string();
 
-        let artist = tag
-            .artist()
-            .ok_or_else(|| MetadataError::MissingField {
-                field: "artist".to_string(),
-                path: file_path.clone(),
-            })?
-            .to_string();
+        let artist = match tag.artist() {
+            Some(a) => a.to_string(),
+            None => {
+                // Fallback to "artists" tag (plural), use first artist
+                tag.get_string(lofty::tag::ItemKey::TrackArtists)
+                    .and_then(|s| {
+                        s.split(|c: char| c == ';' || c == '/')
+                            .next()
+                            .map(|v| v.trim().to_string())
+                            .filter(|v| !v.is_empty())
+                    })
+                    .ok_or_else(|| MetadataError::MissingField {
+                        field: "artist".to_string(),
+                        path: file_path.clone(),
+                    })?
+            }
+        };
 
         // Album artist is optional, fallback to artist
         let album_artist = tag


### PR DESCRIPTION
added fallback for 'artists' tag if 'artist' tag not found.
uses first artist in 'artists' tag as artist. 
this was caused me problems because I have massive library and some files doesn't have 'artist' tag, but has 'artists' tag. now it's fixed. let me know if I need to change anything.