### PR TITLE
Increase metadata tag allocation limit to 64 MB

### DIFF
--- a/src-tauri/src/scanner/scan.rs
+++ b/src-tauri/src/scanner/scan.rs
@@ -6,6 +6,8 @@ use crate::scanner::metadata::extract_track_info;
 use crate::scanner::models::{ScanProgress, ScanResult};
 use anyhow::Result;
 use globwalk::glob;
+use lofty::config::apply_global_options;
+use lofty::config::GlobalOptions;
 use rusqlite::Connection;
 use std::time::{Instant, SystemTime};
 
@@ -43,6 +45,10 @@ pub fn scan_library(
 ) -> Result<ScanResult> {
     let start_time = Instant::now();
     let is_initial_scan = !db::get_init(conn)?;
+
+    // Increase size limit for tag items to 64 MB. Allows files with large cover art to be loaded.
+    let global_options = GlobalOptions::new().allocation_limit(64 * 1024 * 1024);
+    apply_global_options(global_options);
 
     // Phase 1: Mark all tracks as pending
     db::mark_all_tracks_pending(conn)?;


### PR DESCRIPTION
An error I've run into with a few of my files has been the following: ``Error inserting track "<filepath>": Cannot parse metadata from `<filepath>`: Attempted to read/write an abnormally large amount of data``.

I've played around with the underlying Lofty library and identified that metadata tags are [only allowed to be 16 MB or less](https://docs.rs/lofty/0.24.0/src/lofty/config/global_options.rs.html#32). For most files this an adequate amount of space, but my erroring files all had cover art larger than 16 MB.

This PR [changes the limit](https://docs.rs/lofty/0.24.0/lofty/config/struct.GlobalOptions.html#method.allocation_limit) for tags to 64 MB, which was enough to read my files in properly (and in my experience, cover art above ~30 MB is essentially unheard of).

The one potentially confusing thing about the proposed changes is that the option set is called `GlobalOptions` but isn't truly global for the entire program. Instead each call to `apply_global_options` sets the provided options for the thread it executes on. This is why I chose to set the allocation limit at the beginning of the `scan_library` function. Everything inside of that function runs on the same thread and so the options will apply to every file that gets parsed.