### PR TITLE
fix: stop download button spinning forever after completion (#352)

### DIFF
--- a/src/components/library/LibraryHeader.vue
+++ b/src/components/library/LibraryHeader.vue
@@ -67,7 +67,7 @@
       </button>
 
       <button
-        v-else-if="isDownloading && downloadedCount !== totalCount"
+        v-else-if="isDownloading && downloadedCount !== downloadTotalCount"
         class="button button-working h-full min-w-[12rem] px-2 text-xs rounded-full"
         @click.prevent="$emit('showDownloadViewer')"
       >


### PR DESCRIPTION
### Problem
After a bulk download completes (x == y), the header button stays stuck on the animated "Downloading x/y" spinner instead of switching to the "Downloaded x/y" state (issue #352). The counts are correct and complete — it's a UI-condition bug.

### Cause
In `LibraryHeader.vue`, the downloader's `totalCount` is destructured under an alias (`totalCount: downloadTotalCount`) to avoid clashing with the exporter's `totalCount`. The display strings use the alias, but the "downloading" condition still referenced `totalCount`, which no longer exists in the component scope and evaluates to `undefined`. So `downloadedCount !== totalCount` is always `true`, the spinner branch always wins, and the `v-else-if="isDownloading"` "Downloaded" branch is unreachable.

### Fix
Compare against the actual alias, `downloadTotalCount`, so the button transitions to the "Downloaded x/y" state on completion.

```diff
- v-else-if="isDownloading && downloadedCount !== totalCount"
+ v-else-if="isDownloading && downloadedCount !== downloadTotalCount"
```

Verified with `npm run tauri dev` on macOS: the spinner now correctly resolves to the "Downloaded" state. `DownloadViewer.vue` binds `totalCount` without an alias, so it's unaffected.

Fixes #352