### PR TITLE
feat: remember export format selections across exports and restarts

### DIFF
--- a/src/components/library/LibraryHeader.vue
+++ b/src/components/library/LibraryHeader.vue
@@ -225,7 +225,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import DownloadMultiple from '~icons/mdi/download-multiple'
 import Loading from '~icons/mdi/loading'
 import Check from '~icons/mdi/check'
@@ -253,14 +253,46 @@ const emit = defineEmits([
   'showExportViewer',
 ])
 
-const exportPlainText = ref(false)
-const exportSyncedLrc = ref(false)
-const embedIntoTrack = ref(false)
+// Remember the export format selections across exports and app restarts so the
+// user doesn't have to re-check the same boxes every time.
+const EXPORT_PREFS_STORAGE_KEY = 'lrcget:export-format-prefs'
+
+const loadExportPrefs = () => {
+  try {
+    const raw = window.localStorage.getItem(EXPORT_PREFS_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch (error) {
+    console.error('Failed to load export format preferences', error)
+    return null
+  }
+}
+
+const savedExportPrefs = loadExportPrefs()
+
+const exportPlainText = ref(savedExportPrefs?.plainText ?? false)
+const exportSyncedLrc = ref(savedExportPrefs?.syncedLrc ?? false)
+const embedIntoTrack = ref(savedExportPrefs?.embedIntoTrack ?? false)
 const tryEmbedLyrics = ref(false)
+
+watch([exportPlainText, exportSyncedLrc, embedIntoTrack], ([plainText, syncedLrc, embed]) => {
+  try {
+    window.localStorage.setItem(
+      EXPORT_PREFS_STORAGE_KEY,
+      JSON.stringify({ plainText, syncedLrc, embedIntoTrack: embed })
+    )
+  } catch (error) {
+    console.error('Failed to save export format preferences', error)
+  }
+})
 
 const refreshEmbedConfig = async () => {
   const config = await invoke('get_config')
   tryEmbedLyrics.value = config.try_embed_lyrics
+  // Don't keep a remembered "embed" selection active when the feature is
+  // disabled in settings — the checkbox is disabled in that case.
+  if (!tryEmbedLyrics.value) {
+    embedIntoTrack.value = false
+  }
 }
 
 onMounted(refreshEmbedConfig)


### PR DESCRIPTION
### Problem
The Export dropdown's format checkboxes (**Plain lyrics `.txt`**, **Synced lyrics `.lrc`**, **Embed into track**) reset to unchecked every time the dropdown is opened, so the user has to re-select the same options on every export.

### Change
Persist the three selections and restore them automatically:

- Load saved selections on mount and pre-check the boxes.
- Save on any change, so preferences survive both repeated exports **and** app restarts.
- Uses `window.localStorage` — the same persistence mechanism already used for keyboard-shortcut overrides (`composables/edit-lyrics-v2/shortcutRegistry.js`) — so there's no backend/DB change.
- A remembered "Embed into track" selection is cleared when the embed feature is disabled in settings, matching the disabled checkbox state (so it can't silently stay active).

### Notes
Frontend-only, no migration. If you'd prefer these live in the DB `config` alongside `try_embed_lyrics` so they show up as first-class settings, happy to rework it that way.