### PR TITLE
Fix verify_nonce not comparing last byte

### DIFF
--- a/src-tauri/src/lrclib/challenge_solver.rs
+++ b/src-tauri/src/lrclib/challenge_solver.rs
@@ -6,7 +6,7 @@ fn verify_nonce(result: &Vec<u8>, target: &Vec<u8>) -> bool {
         return false;
     }
 
-    for i in 0..(result.len() - 1) {
+    for i in 0..result.len() {
         if result[i] > target[i] {
             return false;
         } else if result[i] < target[i] {


### PR DESCRIPTION
https://github.com/tranxuanthang/lrcget/blob/5ce463c71509d4d762ea97a33e839472bf93d7e9/src-tauri/src/lrclib/challenge_solver.rs#L9

```rust
fn verify_nonce(result: &Vec<u8>, target: &Vec<u8>) -> bool {
    if result.len() != target.len() {
        return false;
    }

    for i in 0..(result.len() - 1) { // not inclusive
        if result[i] > target[i] {
            return false;
        } else if result[i] < target[i] {
            break;
        }
    }

    return true;
}
```

https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=d12899bed97d9ad5a204cf7eb6aabfe1

The fix for #383, since it's tiny thought I would throw the PR